### PR TITLE
Disable autocomplete of input in relay

### DIFF
--- a/src/client/components/ExcerciseForm.tsx
+++ b/src/client/components/ExcerciseForm.tsx
@@ -88,6 +88,7 @@ export const ExcerciseForm: React.FunctionComponent<MyProps> = (props: MyProps) 
             form: { handleChange },
           }: any) => <input
             autoFocus={sentAnswer>0}
+            autoComplete="off"
             {...field}
             onChange={(e)=>{
                 e.preventDefault();


### PR DESCRIPTION
Some browsers suggest previous guesses. This can be problematic if teams use the same computer in their school.

![image](https://github.com/user-attachments/assets/8f557c90-d4cd-408d-ae73-56a912eec81a)
