### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM node:24
 
 WORKDIR /usr/src/app
-COPY package*.json /usr/src/app/
-COPY turbo.json /usr/src/app/
-COPY .npmrc /usr/src/app/
+
+# Copy dependency metadata first (root + all workspaces)
+COPY package.json package-lock.json turbo.json .npmrc ./
+COPY --parents apps/*/package.json packages/*/package.json ./
+
+# Install deps (cached unless package*.json or .npmrc change)
+RUN npm ci
+
+# Copy source code
 COPY . .
 
-RUN npm ci
+# Initial build needed: dev mode (tsc --watch + nodemon) expects dist/ to already exist
 RUN npx turbo build --filter=online-backend
 
 EXPOSE 8000


### PR DESCRIPTION
- Copy source code after npm ci results better docker caching when running docker compose build
- Added npx turbo build:
> <img width="419" height="371" alt="image" src="https://github.com/user-attachments/assets/7019a47b-6fa0-4a89-a3b6-aabb3b4f3e1b" />