### PR TITLE
Add a Language switcher dropdown for the admin page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Run build
         run: npm run build
 
+  i18n:
+    name: i18n
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 22
+      - name: Install Node.js dependencies
+        run: npm ci
+
   # tests:
   #   name: client tests
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Run i18next validation
-        run: npm run i18n:check
+        run: npm run i18n:check -- -s hu  -l packages/common-frontend/public
 
   # tests:
   #   name: client tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Run i18next validation
-        run: npm run i18n:check -- -s hu  -l packages/common-frontend/public
+        run: npm run i18n:check
 
   # tests:
   #   name: client tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           node-version: 22
       - name: Install Node.js dependencies
         run: npm ci
+      - name: Run i18next validation
+        run: npm run i18next:check
 
   # tests:
   #   name: client tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Run i18next validation
-        run: npm run i18next:check
+        run: npm run i18n:check
 
   # tests:
   #   name: client tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,5 @@
   "i18n-ally.defaultNamespace": "translation",
   "i18n-ally.sourceLanguage": "hu",
   "i18n-ally.keystyle": "nested",
+  "i18n-ally.namespace": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
+        "@lingual/i18n-check": "^0.9.5",
         "@sentry/types": "^7.57.0",
         "@types/koa__cors": "^5.0.1",
         "@types/pg": "^8.6.5",
@@ -1955,6 +1956,285 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@formatjs/cli-lib": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli-lib/-/cli-lib-8.7.0.tgz",
+      "integrity": "sha512-ourUlQlF4qs2umF4dZNrfM6WAwBlm/vXkXebQsWdwbYQtHGb5JyhoTjqbTb3SOPx11uyD2as78y1v50naRwzww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "3.5.9",
+        "@formatjs/icu-skeleton-parser": "2.1.9",
+        "@formatjs/ts-transformer": "4.4.9",
+        "@types/estree": "^1.0.8",
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "22 || 24",
+        "commander": "^14.0.0",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.3",
+        "json-stable-stringify": "^1.3.0",
+        "loud-rejection": "^2",
+        "typescript": "^5.6 || 6"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      },
+      "optionalDependencies": {
+        "@formatjs/cli-native-darwin-arm64": "1.1.0",
+        "@formatjs/cli-native-linux-arm64": "1.2.0",
+        "@formatjs/cli-native-linux-x64": "1.1.0"
+      },
+      "peerDependencies": {
+        "@glimmer/syntax": "^0.84.3 || ^0.95.0",
+        "@vue/compiler-core": "^3.5.0",
+        "content-tag": "^4.1.0",
+        "svelte": "^5.0.0",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@glimmer/env": {
+          "optional": true
+        },
+        "@glimmer/reference": {
+          "optional": true
+        },
+        "@glimmer/syntax": {
+          "optional": true
+        },
+        "@glimmer/validator": {
+          "optional": true
+        },
+        "@vue/compiler-core": {
+          "optional": true
+        },
+        "content-tag": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.9.tgz",
+      "integrity": "sha512-PZm6O9JI/gUPtQV9r2eaMuLb4yWqV2vz+ot03ORHWTKO343LSpZi0TqeXLB2ZZGDXLCw2SbfgsQ0GxoxXMl79g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.9"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@formatjs/cli-native-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli-native-darwin-arm64/-/cli-native-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-ygEpFpmRjbAKanWaeto/eUItyuK18667mdDzpDg3CTzc15WYzjZKnwJNFUuPFvFA4hiod1tnhXT1eiXmc1wWNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@formatjs/cli-native-linux-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli-native-linux-arm64/-/cli-native-linux-arm64-1.2.0.tgz",
+      "integrity": "sha512-G6YuIVD8D6hZjnsD/aYZQ2qMHSve7IadEiXgKiDfFQBbyrkjDAlt6LDSqq4qnuv3WJ7/jAOn/An6n/bGyt0rLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@formatjs/cli-native-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli-native-linux-x64/-/cli-native-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-AxORf5LR14HvXU4ov9gnhLrNIS2DYKqKMkRkprUhuh+ljba1riF05msK8KzslEPYQoeYKc5A0OZp57poh4xz/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-4.4.9.tgz",
+      "integrity": "sha512-AOiNZHLc9cI71AJuRo1FrHIHyISNDXBov7L+aPThKyp7d545s8ZcNhLpVC3Neu3IZZBR2xWXzjgd/QoUX8O6jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "3.5.9",
+        "@types/node": "22 || 24",
+        "json-stable-stringify": "^1.3.0",
+        "typescript": "^5.6 || 6"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      },
+      "peerDependencies": {
+        "ts-jest": "^29"
+      },
+      "peerDependenciesMeta": {
+        "ts-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.9.tgz",
+      "integrity": "sha512-PZm6O9JI/gUPtQV9r2eaMuLb4yWqV2vz+ot03ORHWTKO343LSpZi0TqeXLB2ZZGDXLCw2SbfgsQ0GxoxXMl79g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.9"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2182,6 +2462,155 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@lingual/i18n-check": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@lingual/i18n-check/-/i18n-check-0.9.5.tgz",
+      "integrity": "sha512-lRlDbY3ysZoiS0meGpwvOL1e7z5F9bMIdmOWBcfUz5obRfZvDBI4YVKUZvzp3CGS0OIJmEp1WBFZ3XxTX9OWzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/cli-lib": "^8.5.1",
+        "@formatjs/icu-messageformat-parser": "^2.11.4",
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
+        "glob": "^13.0.6",
+        "typescript": "^5.9.3",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "i18n-check": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lingual/i18n-check/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -3269,6 +3698,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "2.3.10",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
@@ -3318,6 +3758,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
@@ -3976,6 +4426,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-timsort": {
@@ -5235,6 +5695,19 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5302,6 +5775,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-equal": {
       "version": "1.0.1",
@@ -7928,6 +8408,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -7955,6 +8455,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/keygrip": {
@@ -8335,6 +8845,20 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loud-rejection": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+      "integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -8500,11 +9024,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -14641,7 +15165,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14711,6 +15234,13 @@
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dev:server": "turbo dev --filter=online-backend --filter=game --filter=schemas --filter=strategy",
     "dev:online": "turbo dev --filter=online-frontend --filter=game --filter=common-frontend",
     "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend",
-    "i18n:check": "i18n-check -f i18next -s hu -l packages/common-frontend/public -u ./**/src -i disclaimer.interfaceDescription disclaimer.interfaceDescriptionOfflineMode"
+    "i18n:check": "i18n-check -f i18next -s hu -l packages/common-frontend/public -u ./**/src"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dev:server": "turbo dev --filter=online-backend --filter=game --filter=schemas --filter=strategy",
     "dev:online": "turbo dev --filter=online-frontend --filter=game --filter=common-frontend",
     "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend",
-    "i18n:check": "i18n-check -f i18next"
+    "i18n:check": "i18n-check -f i18next -s hu -l packages/common-frontend/public -u ./**/src -i disclaimer.interfaceDescription disclaimer.interfaceDescriptionOfflineMode"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "spell-check": "cspell \"**/*.{ts,tsx}\" --no-progress",
     "dev:server": "turbo dev --filter=online-backend --filter=game --filter=schemas --filter=strategy",
     "dev:online": "turbo dev --filter=online-frontend --filter=game --filter=common-frontend",
-    "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend"
+    "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend",
+    "i18n:check": "i18n-check"
   },
   "eslintConfig": {
     "extends": [
@@ -104,6 +105,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.37.0",
+    "@lingual/i18n-check": "^0.9.5",
     "@sentry/types": "^7.57.0",
     "@types/koa__cors": "^5.0.1",
     "@types/pg": "^8.6.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dev:server": "turbo dev --filter=online-backend --filter=game --filter=schemas --filter=strategy",
     "dev:online": "turbo dev --filter=online-frontend --filter=game --filter=common-frontend",
     "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend",
-    "i18n:check": "i18n-check"
+    "i18n:check": "i18n-check -f i18next"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dev:server": "turbo dev --filter=online-backend --filter=game --filter=schemas --filter=strategy",
     "dev:online": "turbo dev --filter=online-frontend --filter=game --filter=common-frontend",
     "dev:offline": "turbo dev --filter=offline-frontend --filter=game --filter=strategy --filter=common-frontend",
-    "i18n:check": "i18n-check -f i18next -s hu -l packages/common-frontend/public -u ./**/src"
+    "i18n:check": "i18n-check --format i18next --source hu --locales packages/common-frontend/public --unused ./**/src"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/common-frontend/public/locales/en/translation.json
+++ b/packages/common-frontend/public/locales/en/translation.json
@@ -57,7 +57,7 @@
     },
     "general": {
       "loading": "Loading game or task…",
-      "points_one": "1 points",
+      "points_one": "1 point",
       "points_other": "{{count}} points",
       "remainingTime": "Remaining time",
       "returnHome": "Back to main page",

--- a/packages/common-frontend/public/locales/en/translation.json
+++ b/packages/common-frontend/public/locales/en/translation.json
@@ -1,56 +1,32 @@
 {
+  "chooser": {
+    "achievedPoint": "Points achieved",
+    "filledAt": "Filled at",
+    "finish": {
+      "content": "Thank you for participating, we hope you enjoyed the competition. We are curious about your feedback on this round, so please <a>fill out this form</a>. We will publish the results and the list of advancing teams by Thursday, and we will also send you a notification about it by email.",
+      "final": "Final score",
+      "title": "Competition ended!"
+    },
+    "gameDescriptionHtml": "<p>In this task, you can play a two-player strategy game where you will be one player and the computer will be the other. Defeat the computer <b>twice in a row</b> in this game! Knowing the starting position, you can decide whether you want to play as the first or second player.</p>\n            <p>You will receive points for successful completion as follows:\n              <ul>\n            <li>If you don't lose at all, you get 12 points.</li>\n            <li>In case of 1, 2, 3, 4, or 5 losses, the points obtained decrease to 9, 6, 4, 3, and 2 respectively.</li>\n            <li>In case of more losses, you still get 2 points if you manage to complete the game.</li>\n            <li>If you fail to defeat the computer twice in a row within 30 minutes, you get 0 points.</li>\n              </ul>\n            </p>\n            <p>\n              When you're ready, click the button below and from then on you have a total of 30 minutes.\n            </p>",
+    "pointsNotSettled": "Your final points are only here for informational purposes, these will be reevaluated based on all the submissions we get.",
+    "relayDescription": "Relay tasks are short text tasks where the answer is an integer (at least 0 and at most 9999). You can make a maximum of 3 guesses for each relay task, and after each wrong guess, the points you can earn for that task decrease by 1. After a correct guess or three wrong guesses, you will receive the next task. You have a total of 60 minutes for the relay tasks, and you can earn a total of 40 points with error-free performance. (The points available for individual tasks range from 3 to 6.)",
+    "result": "Results",
+    "start": "Start"
+  },
   "disclaimer": {
-    "welcome": "Dear Team <i>{{tname}}</i>, welcome to the online round!",
     "category": "Your category: <b>{{category}}</b>",
-    "start": "In the online round, teams must work on their own; they must not ask for help from other people until the competition ends (at 21:30). The use of artificial intelligence is also forbidden.",
-    "progress": "Advancing to next rounds",
-    "progressDescription": "Teams that earn at least {{minpoints}} points out of the maximum {{maxpoints}} points that can be earned will proceed to the regional round. (We reserve the right to lower this minimum threshold, but we will not raise it.) The points earned in the online round do not count towards the later results.",
+    "continue": "Continue to the competition",
     "interface": "The interface",
     "interfaceDescription": "The interface can be filled in using your PCs or phones as well. You can even log in from multiple devices.",
     "interfaceDescriptionOfflineMode": "The interface can be filled in on both mobile and computer. Please make sure to complete the online round from <b>at most 1 device</b>, and also <b>do not refresh the page</b> during the competition.<br /><small>(If you nevertheless refresh the page, the competition will restart (but your results so far will be kept). In that case, go back as quickly as possible to the task where you left off. Note that although the timer restarts after refreshing, we will still only take into account answers that arrive within the official time limit.)</small>",
-    "continue": "Continue to the competition"
+    "progress": "Advancing to next rounds",
+    "progressDescription": "Teams that earn at least {{minpoints}} points out of the maximum {{maxpoints}} points that can be earned will proceed to the regional round. (We reserve the right to lower this minimum threshold, but we will not raise it.) The points earned in the online round do not count towards the later results.",
+    "start": "In the online round, teams must work on their own; they must not ask for help from other people until the competition ends (at 21:30). The use of artificial intelligence is also forbidden.",
+    "welcome": "Dear Team <i>{{tname}}</i>, welcome to the online round!"
   },
-  "chooser": {
-    "finish": {
-      "title": "Competition ended!",
-      "content": "Thank you for participating, we hope you enjoyed the competition. We are curious about your feedback on this round, so please <a>fill out this form</a>. We will publish the results and the list of advancing teams by Thursday, and we will also send you a notification about it by email.",
-      "final": "Final score"
-    },
-    "gameDescriptionHtml": "<p>In this task, you can play a two-player strategy game where you will be one player and the computer will be the other. Defeat the computer <b>twice in a row</b> in this game! Knowing the starting position, you can decide whether you want to play as the first or second player.</p>\n            <p>You will receive points for successful completion as follows:\n              <ul>\n            <li>If you don't lose at all, you get 12 points.</li>\n            <li>In case of 1, 2, 3, 4, or 5 losses, the points obtained decrease to 9, 6, 4, 3, and 2 respectively.</li>\n            <li>In case of more losses, you still get 2 points if you manage to complete the game.</li>\n            <li>If you fail to defeat the computer twice in a row within 30 minutes, you get 0 points.</li>\n              </ul>\n            </p>\n            <p>\n              When you're ready, click the button below and from then on you have a total of 30 minutes.\n            </p>",
-    "relayDescription": "Relay tasks are short text tasks where the answer is an integer (at least 0 and at most 9999). You can make a maximum of 3 guesses for each relay task, and after each wrong guess, the points you can earn for that task decrease by 1. After a correct guess or three wrong guesses, you will receive the next task. You have a total of 60 minutes for the relay tasks, and you can earn a total of 40 points with error-free performance. (The points available for individual tasks range from 3 to 6.)",
-    "filledAt": "Filled at",
-    "achievedPoint": "Points achieved",
-    "start": "Start",
-    "result": "Results",
-    "pointsNotSettled": "Your final points are only here for informational purposes, these will be reevaluated based on all the submissions we get."
-  },
-  "relay": {
-    "endTable": {
-      "task": "Task",
-      "point": "Points",
-      "try_one": "in 1 attempt",
-      "try_other": "in {{count}} attempts",
-      "wrong": "Wrong answer",
-      "all": "Total points",
-      "back": "Back to competition",
-      "reminder": "Don't forget to play with the strategy game too if you haven't done yet!"
-    },
-    "error": {
-      "duplicate": "You've already tried this guess",
-      "integer": "You must give an integer",
-      "type": "Answer must be a number",
-      "range": "The solution is between 0 and 9999",
-      "badCategory": "WRONG CATEGORY",
-      "empty": "You didn't give any answer!"
-    },
-    "goodGuess": "Your answer is correct",
-    "wrongGuess": "Your guess is sadly wrong",
-    "name": "Relay tasks",
-    "guess": "Guess:",
-    "send": "Submit",
-    "guessNum": "Guess #{{guessnum}}:",
-    "task": "Task #{{num}} ({{maxpoints}})",
-    "taskImage": "Image belonging to the current task (if it didn't load properly, try refreshing the page)"
+  "error": {
+    "notFound": "This page was not found.",
+    "unexpected": "An unexpected error occurred"
   },
   "general": {
     "loading": "Loading game or task…",
@@ -65,63 +41,88 @@
   },
   "header": {
     "logout": "logout",
+    "logoutofthiswholething": "",
     "subtitle": "Online round",
     "title": "XIX. Dürer Competition"
   },
   "login": {
-    "greeting": "Dear Competitor!",
-    "beforeTitle": "Welcome to the online round interface of the ",
     "afterTitle": ".",
-    "loginInstruction": "To log in, check your emails and enter the code you find there here:",
-    "fallback": "If you can't find the email, write to us at the verseny (at) durerinfo (dot) hu email address.",
-    "loginButton": "Log in",
+    "beforeTitle": "Welcome to the online round interface of the ",
     "error": {
       "empty": "You didn't give any code!",
       "wrongid": "Incorrect log-in code."
-    }
+    },
+    "fallback": "If you can't find the email, write to us at the verseny (at) durerinfo (dot) hu email address.",
+    "greeting": "Dear Competitor!",
+    "loginButton": "Log in",
+    "loginInstruction": "To log in, check your emails and enter the code you find there here:"
   },
-  "waitingRoom": {
-    "soon": "The online round will start soon!",
-    "remainingStart": "Still",
-    "remainingEnd": "left until start!",
-    "instruction": "When the competition starts, you will be automatically redirected to the competition interface."
+  "relay": {
+    "endTable": {
+      "all": "Total points",
+      "back": "Back to competition",
+      "point": "Points",
+      "reminder": "Don't forget to play with the strategy game too if you haven't done yet!",
+      "task": "Task",
+      "try_one": "in 1 attempt",
+      "try_other": "in {{count}} attempts",
+      "wrong": "Wrong answer"
+    },
+    "error": {
+      "badCategory": "WRONG CATEGORY",
+      "duplicate": "You've already tried this guess",
+      "empty": "You didn't give any answer!",
+      "integer": "You must give an integer",
+      "range": "The solution is between 0 and 9999",
+      "type": "Answer must be a number"
+    },
+    "goodGuess": "Your answer is correct",
+    "guess": "Guess:",
+    "guessNum": "Guess #{{guessnum}}:",
+    "name": "Relay tasks",
+    "send": "Submit",
+    "task": "Task #{{num}} ({{maxpoints}})",
+    "taskImage": "Image belonging to the current task (if it didn't load properly, try refreshing the page)",
+    "wrongGuess": "Your guess is sadly wrong"
   },
   "strategy": {
-    "notSupported": "UNSUPPORTED GAME STATE",
-    "name": "Strategy game",
-    "description": "Description",
-    "instructions": "Further instructions",
-    "instructionDescription": "Clicking on the button “Start a new test game” starts a test game, which is not counted in the scoring. Feel free to play some test games before playing a real round in order to test your understanding of the game's logic. The latter mode can be initialised by clicking “Start a new live game”, which will start a game which now counts for points.",
-    "realResults": "Live game results so far: {{wins}}, {{defeats}}",
-    "wins_one": "1 win",
-    "wins_other": "{{count}} wins",
     "defeats_one": "1 defeat",
     "defeats_other": "{{count}} defeats",
-    "testGameButton": "Start a new test game",
-    "realGameButton": "Start a new live game",
-    "firstPlayer": "I will be the first",
-    "secondPlayer": "I will be the second",
+    "description": "Description",
     "endTable": {
       "all": "Total points",
       "gained": "Points earned",
       "tries": "Number of attempts"
     },
+    "firstPlayer": "I will be the first",
     "guide": {
-      "newGame": "Start a new game!",
-      "ifFirstPlayer": "Choose whether you want to be the first or second player.",
-      "yourTurn": "Your turn now!",
-      "waitingForServer": "Waiting for server...",
-      "realGameWin": "Congratulations, you won! Defeat the computer next time as well to achieve full victory!",
-      "testGameWin": "Congratulations, you won the test game!",
+      "actions": "Actions",
       "botWins": "Unfortunately the computer won.",
       "endOfGame": "The game has ended.",
+      "ifFirstPlayer": "Choose whether you want to be the first or second player.",
       "liveStarted": "Live game started.",
+      "newGame": "Start a new game!",
+      "realGameWin": "Congratulations, you won! Defeat the computer next time as well to achieve full victory!",
+      "testGameWin": "Congratulations, you won the test game!",
       "testStarted": "Test game started.",
-      "actions": "Actions"
-    }
+      "waitingForServer": "Waiting for server...",
+      "yourTurn": "Your turn now!"
+    },
+    "instructionDescription": "Clicking on the button “Start a new test game” starts a test game, which is not counted in the scoring. Feel free to play some test games before playing a real round in order to test your understanding of the game's logic. The latter mode can be initialised by clicking “Start a new live game”, which will start a game which now counts for points.",
+    "instructions": "Further instructions",
+    "name": "Strategy game",
+    "notSupported": "UNSUPPORTED GAME STATE",
+    "realGameButton": "Start a new live game",
+    "realResults": "Live game results so far: {{wins}}, {{defeats}}",
+    "secondPlayer": "I will be the second",
+    "testGameButton": "Start a new test game",
+    "wins_one": "1 win",
+    "wins_other": "{{count}} wins"
   },
-  "error": {
-    "unexpected": "An unexpected error occurred",
-    "notFound": "This page was not found."
+  "waitingRoom": {
+    "instruction": "When the competition starts, you will be automatically redirected to the competition interface.",
+    "remainingEnd": "left until start!",
+    "remainingStart": "Still",
+    "soon": "The online round will start soon!"
   }
 }

--- a/packages/common-frontend/public/locales/en/translation.json
+++ b/packages/common-frontend/public/locales/en/translation.json
@@ -1,9 +1,5 @@
 {
   "translation": {
-    "languages": {
-      "en": "English",
-      "hu": "Hungarian"
-    },
     "disclaimer": {
       "welcome": "Dear Team <i>{{tname}}</i>, welcome to the online round!",
       "category": "Your category: <b>{{category}}</b>",
@@ -55,13 +51,14 @@
       "name": "Relay tasks",
       "guess": "Guess:",
       "send": "Submit",
-      "guessNum": "guess #{{guessnum}}:",
+      "guessNum": "Guess #{{guessnum}}:",
+      "task": "Task #{{num}} ({{maxpoints}})",
       "taskImage": "Image belonging to the current task (if it didn't load properly, try refreshing the page)"
     },
     "general": {
       "loading": "Loading game or task…",
-      "task": "task",
-      "point": "point",
+      "points_one": "1 points",
+      "points_other": "{{count}} points",
       "remainingTime": "Remaining time",
       "returnHome": "Back to main page",
       "warning": {
@@ -117,7 +114,7 @@
         "ifFirstPlayer": "Choose whether you want to be the first or second player.",
         "yourTurn": "Your turn now!",
         "waitingForServer": "Waiting for server...",
-        "realGameWin": "Congratulations, you won! Defeat the computer one more time!",
+        "realGameWin": "Congratulations, you won! Defeat the computer next time as well to achieve full victory!",
         "testGameWin": "Congratulations, you won the test game!",
         "botWins": "Unfortunately the computer won.",
         "endOfGame": "The game has ended.",

--- a/packages/common-frontend/public/locales/en/translation.json
+++ b/packages/common-frontend/public/locales/en/translation.json
@@ -1,132 +1,127 @@
 {
-  "translation": {
-    "disclaimer": {
-      "welcome": "Dear Team <i>{{tname}}</i>, welcome to the online round!",
-      "category": "Your category: <b>{{category}}</b>",
-      "start": "In the online round, teams must work on their own; they must not ask for help from other people until the competition ends (at 21:30). The use of artificial intelligence is also forbidden.",
-      "progress": "Advancing to next rounds",
-      "progressDescription": "Teams that earn at least {{minpoints}} points out of the maximum {{maxpoints}} points that can be earned will proceed to the regional round. (We reserve the right to lower this minimum threshold, but we will not raise it.) The points earned in the online round do not count towards the later results.",
-      "interface": "The interface",
-      "interfaceDescription": "The interface can be filled in using your PCs or phones as well. You can even log in from multiple devices.",
-      "interfaceDescriptionOfflineMode": "The interface can be filled in on both mobile and computer. Please make sure to complete the online round from <b>at most 1 device</b>, and also <b>do not refresh the page</b> during the competition.<br /><small>(If you nevertheless refresh the page, the competition will restart (but your results so far will be kept). In that case, go back as quickly as possible to the task where you left off. Note that although the timer restarts after refreshing, we will still only take into account answers that arrive within the official time limit.)</small>",
-      "continue": "Continue to the competition"
+  "disclaimer": {
+    "welcome": "Dear Team <i>{{tname}}</i>, welcome to the online round!",
+    "category": "Your category: <b>{{category}}</b>",
+    "start": "In the online round, teams must work on their own; they must not ask for help from other people until the competition ends (at 21:30). The use of artificial intelligence is also forbidden.",
+    "progress": "Advancing to next rounds",
+    "progressDescription": "Teams that earn at least {{minpoints}} points out of the maximum {{maxpoints}} points that can be earned will proceed to the regional round. (We reserve the right to lower this minimum threshold, but we will not raise it.) The points earned in the online round do not count towards the later results.",
+    "interface": "The interface",
+    "interfaceDescription": "The interface can be filled in using your PCs or phones as well. You can even log in from multiple devices.",
+    "interfaceDescriptionOfflineMode": "The interface can be filled in on both mobile and computer. Please make sure to complete the online round from <b>at most 1 device</b>, and also <b>do not refresh the page</b> during the competition.<br /><small>(If you nevertheless refresh the page, the competition will restart (but your results so far will be kept). In that case, go back as quickly as possible to the task where you left off. Note that although the timer restarts after refreshing, we will still only take into account answers that arrive within the official time limit.)</small>",
+    "continue": "Continue to the competition"
+  },
+  "chooser": {
+    "finish": {
+      "title": "Competition ended!",
+      "content": "Thank you for participating, we hope you enjoyed the competition. We are curious about your feedback on this round, so please <a>fill out this form</a>. We will publish the results and the list of advancing teams by Thursday, and we will also send you a notification about it by email.",
+      "final": "Final score"
     },
-    "chooser": {
-      "finish": {
-        "title": "Competition ended!",
-        "content": "Thank you for participating, we hope you enjoyed the competition. We are curious about your feedback on this round, so please <a>fill out this form</a>. We will publish the results and the list of advancing teams by Thursday, and we will also send you a notification about it by email.",
-        "final": "Final score"
-      },
-      "gameDescriptionHtml": "<p>In this task, you can play a two-player strategy game where you will be one player and the computer will be the other. Defeat the computer <b>twice in a row</b> in this game! Knowing the starting position, you can decide whether you want to play as the first or second player.</p>\n            <p>You will receive points for successful completion as follows:\n              <ul>\n            <li>If you don't lose at all, you get 12 points.</li>\n            <li>In case of 1, 2, 3, 4, or 5 losses, the points obtained decrease to 9, 6, 4, 3, and 2 respectively.</li>\n            <li>In case of more losses, you still get 2 points if you manage to complete the game.</li>\n            <li>If you fail to defeat the computer twice in a row within 30 minutes, you get 0 points.</li>\n              </ul>\n            </p>\n            <p>\n              When you're ready, click the button below and from then on you have a total of 30 minutes.\n            </p>",
-      "relayDescription": "Relay tasks are short text tasks where the answer is an integer (at least 0 and at most 9999). You can make a maximum of 3 guesses for each relay task, and after each wrong guess, the points you can earn for that task decrease by 1. After a correct guess or three wrong guesses, you will receive the next task. You have a total of 60 minutes for the relay tasks, and you can earn a total of 40 points with error-free performance. (The points available for individual tasks range from 3 to 6.)",
-      "filledAt": "Filled at",
-      "achievedPoint": "Points achieved",
-      "start": "Start",
-      "result": "Results",
-      "pointsNotSettled": "Your final points are only here for informational purposes, these will be reevaluated based on all the submissions we get."
-    },
-    "relay": {
-      "endTable": {
-        "title": "Relay completed",
-        "task": "Task",
-        "point": "Points",
-        "try_one": "in 1 attempt",
-        "try_other": "in {{count}} attempts",
-        "wrong": "Wrong answer",
-        "all": "Total points",
-        "pointsGained": "points scored",
-        "back": "Back to competition",
-        "reminder": "Don't forget to play with the strategy game too if you haven't done yet!"
-      },
-      "error": {
-        "duplicate": "You've already tried this guess",
-        "integer": "You must give an integer",
-        "type": "Answer must be a number",
-        "range": "The solution is between 0 and 9999",
-        "badCategory": "WRONG CATEGORY",
-        "empty": "You didn't give any answer!"
-      },
-      "goodGuess": "Your answer is correct",
-      "wrongGuess": "Your guess is sadly wrong",
-      "name": "Relay tasks",
-      "guess": "Guess:",
-      "send": "Submit",
-      "guessNum": "Guess #{{guessnum}}:",
-      "task": "Task #{{num}} ({{maxpoints}})",
-      "taskImage": "Image belonging to the current task (if it didn't load properly, try refreshing the page)"
-    },
-    "general": {
-      "loading": "Loading game or task…",
-      "points_one": "1 point",
-      "points_other": "{{count}} points",
-      "remainingTime": "Remaining time",
-      "returnHome": "Back to main page",
-      "warning": {
-        "timeNotMatch": "Your computer's clock is not synchronized with the server's clock, the displayed remaining time is not perfect, reloading the page may solve the problem",
-        "timeNotReal": "The clock is for informational purposes only. You will see a different time on other devices and browsers, but we will still only consider answers received on time."
-      }
-    },
-    "header": {
-      "logout": "logout",
-      "subtitle": "Online round",
-      "title": "XIX. Dürer Competition"
-    },
-    "login": {
-      "greeting": "Dear Competitor!",
-      "beforeTitle": "Welcome to the online round interface of the ",
-      "afterTitle": ".",
-      "loginInstruction": "To log in, check your emails and enter the code you find there here:",
-      "fallback": "If you can't find the email, write to us at the verseny (at) durerinfo (dot) hu email address.",
-      "loginButton": "Log in",
-      "error": {
-        "empty": "You didn't give any code!",
-        "wrongid": "Incorrect log-in code."
-      }
-    },
-    "waitingRoom": {
-      "soon": "The online round will start soon!",
-      "remainingStart": "Still",
-      "remainingEnd": "left until start!",
-      "instruction": "When the competition starts, you will be automatically redirected to the competition interface."
-    },
-    "strategy": {
-      "notSupported": "UNSUPPORTED GAME STATE",
-      "name": "Strategy game",
-      "description": "Description",
-      "instructions": "Further instructions",
-      "instructionDescription": "Clicking on the button “Start a new test game” starts a test game, which is not counted in the scoring. Feel free to play some test games before playing a real round in order to test your understanding of the game's logic. The latter mode can be initialised by clicking “Start a new live game”, which will start a game which now counts for points.",
-      "realResults": "Live game results so far: {{wins}}, {{defeats}}",
-      "wins_one": "1 win",
-      "wins_other": "{{count}} wins",
-      "defeats_one": "1 defeat",
-      "defeats_other": "{{count}} defeats",
-      "testGameButton": "Start a new test game",
-      "realGameButton": "Start a new live game",
-      "firstPlayer": "I will be the first",
-      "secondPlayer": "I will be the second",
-      "endTable": {
-        "all": "Total points",
-        "gained": "Points earned",
-        "tries": "Number of attempts"
-      },
-      "guide": {
-        "newGame": "Start a new game!",
-        "ifFirstPlayer": "Choose whether you want to be the first or second player.",
-        "yourTurn": "Your turn now!",
-        "waitingForServer": "Waiting for server...",
-        "realGameWin": "Congratulations, you won! Defeat the computer next time as well to achieve full victory!",
-        "testGameWin": "Congratulations, you won the test game!",
-        "botWins": "Unfortunately the computer won.",
-        "endOfGame": "The game has ended.",
-        "liveStarted": "Live game started.",
-        "testStarted": "Test game started.",
-        "results": "Results",
-        "actions": "Actions"
-      }
+    "gameDescriptionHtml": "<p>In this task, you can play a two-player strategy game where you will be one player and the computer will be the other. Defeat the computer <b>twice in a row</b> in this game! Knowing the starting position, you can decide whether you want to play as the first or second player.</p>\n            <p>You will receive points for successful completion as follows:\n              <ul>\n            <li>If you don't lose at all, you get 12 points.</li>\n            <li>In case of 1, 2, 3, 4, or 5 losses, the points obtained decrease to 9, 6, 4, 3, and 2 respectively.</li>\n            <li>In case of more losses, you still get 2 points if you manage to complete the game.</li>\n            <li>If you fail to defeat the computer twice in a row within 30 minutes, you get 0 points.</li>\n              </ul>\n            </p>\n            <p>\n              When you're ready, click the button below and from then on you have a total of 30 minutes.\n            </p>",
+    "relayDescription": "Relay tasks are short text tasks where the answer is an integer (at least 0 and at most 9999). You can make a maximum of 3 guesses for each relay task, and after each wrong guess, the points you can earn for that task decrease by 1. After a correct guess or three wrong guesses, you will receive the next task. You have a total of 60 minutes for the relay tasks, and you can earn a total of 40 points with error-free performance. (The points available for individual tasks range from 3 to 6.)",
+    "filledAt": "Filled at",
+    "achievedPoint": "Points achieved",
+    "start": "Start",
+    "result": "Results",
+    "pointsNotSettled": "Your final points are only here for informational purposes, these will be reevaluated based on all the submissions we get."
+  },
+  "relay": {
+    "endTable": {
+      "task": "Task",
+      "point": "Points",
+      "try_one": "in 1 attempt",
+      "try_other": "in {{count}} attempts",
+      "wrong": "Wrong answer",
+      "all": "Total points",
+      "back": "Back to competition",
+      "reminder": "Don't forget to play with the strategy game too if you haven't done yet!"
     },
     "error": {
-      "unexpected": "An unexpected error occurred",
-      "notFound": "This page was not found."
+      "duplicate": "You've already tried this guess",
+      "integer": "You must give an integer",
+      "type": "Answer must be a number",
+      "range": "The solution is between 0 and 9999",
+      "badCategory": "WRONG CATEGORY",
+      "empty": "You didn't give any answer!"
+    },
+    "goodGuess": "Your answer is correct",
+    "wrongGuess": "Your guess is sadly wrong",
+    "name": "Relay tasks",
+    "guess": "Guess:",
+    "send": "Submit",
+    "guessNum": "Guess #{{guessnum}}:",
+    "task": "Task #{{num}} ({{maxpoints}})",
+    "taskImage": "Image belonging to the current task (if it didn't load properly, try refreshing the page)"
+  },
+  "general": {
+    "loading": "Loading game or task…",
+    "points_one": "1 point",
+    "points_other": "{{count}} points",
+    "remainingTime": "Remaining time",
+    "returnHome": "Back to main page",
+    "warning": {
+      "timeNotMatch": "Your computer's clock is not synchronized with the server's clock, the displayed remaining time is not perfect, reloading the page may solve the problem",
+      "timeNotReal": "The clock is for informational purposes only. You will see a different time on other devices and browsers, but we will still only consider answers received on time."
     }
+  },
+  "header": {
+    "logout": "logout",
+    "subtitle": "Online round",
+    "title": "XIX. Dürer Competition"
+  },
+  "login": {
+    "greeting": "Dear Competitor!",
+    "beforeTitle": "Welcome to the online round interface of the ",
+    "afterTitle": ".",
+    "loginInstruction": "To log in, check your emails and enter the code you find there here:",
+    "fallback": "If you can't find the email, write to us at the verseny (at) durerinfo (dot) hu email address.",
+    "loginButton": "Log in",
+    "error": {
+      "empty": "You didn't give any code!",
+      "wrongid": "Incorrect log-in code."
+    }
+  },
+  "waitingRoom": {
+    "soon": "The online round will start soon!",
+    "remainingStart": "Still",
+    "remainingEnd": "left until start!",
+    "instruction": "When the competition starts, you will be automatically redirected to the competition interface."
+  },
+  "strategy": {
+    "notSupported": "UNSUPPORTED GAME STATE",
+    "name": "Strategy game",
+    "description": "Description",
+    "instructions": "Further instructions",
+    "instructionDescription": "Clicking on the button “Start a new test game” starts a test game, which is not counted in the scoring. Feel free to play some test games before playing a real round in order to test your understanding of the game's logic. The latter mode can be initialised by clicking “Start a new live game”, which will start a game which now counts for points.",
+    "realResults": "Live game results so far: {{wins}}, {{defeats}}",
+    "wins_one": "1 win",
+    "wins_other": "{{count}} wins",
+    "defeats_one": "1 defeat",
+    "defeats_other": "{{count}} defeats",
+    "testGameButton": "Start a new test game",
+    "realGameButton": "Start a new live game",
+    "firstPlayer": "I will be the first",
+    "secondPlayer": "I will be the second",
+    "endTable": {
+      "all": "Total points",
+      "gained": "Points earned",
+      "tries": "Number of attempts"
+    },
+    "guide": {
+      "newGame": "Start a new game!",
+      "ifFirstPlayer": "Choose whether you want to be the first or second player.",
+      "yourTurn": "Your turn now!",
+      "waitingForServer": "Waiting for server...",
+      "realGameWin": "Congratulations, you won! Defeat the computer next time as well to achieve full victory!",
+      "testGameWin": "Congratulations, you won the test game!",
+      "botWins": "Unfortunately the computer won.",
+      "endOfGame": "The game has ended.",
+      "liveStarted": "Live game started.",
+      "testStarted": "Test game started.",
+      "actions": "Actions"
+    }
+  },
+  "error": {
+    "unexpected": "An unexpected error occurred",
+    "notFound": "This page was not found."
   }
 }

--- a/packages/common-frontend/public/locales/hu/translation.json
+++ b/packages/common-frontend/public/locales/hu/translation.json
@@ -1,55 +1,32 @@
-{
+{   
+  "chooser": {
+    "achievedPoint": "Elért pontszám",
+    "filledAt": "Kitöltve ekkor",
+    "finish": {
+      "content": "Köszönjük a részvételeteket, reméljük, hogy tetszett nektek a verseny. Kíváncsiak vagyunk a fordulóval kapcsolatos véleményetekre, így kérjük, <a>töltsétek ki ezt az űrlapot</a>. Várhatóan csütörtökig közzétesszük az eredményeket és a továbbjutó csapatok listáját, és erről emailben is fogunk nektek értesítést küldeni.",
+      "final": "Végső pontszám",
+      "title": "Vége a versenynek!"
+    },
+    "gameDescriptionHtml": "<p>Ebben a feladatban egy kétszemélyes stratégiás játékot játszhattok, ahol az egyik játékos Ti lesztek, a másik játékos pedig a gép. Győzzétek le a gépet <b>kétszer egymás után</b> ebben a játékban! A kezdő helyzet ismeretében Ti dönthetitek el, hogy a kezdő vagy a második játékos bőrébe szeretnétek bújni.</p>         \n            <p>A sikeres teljesítésért az alábbiak szerint kaptok pontot:\n              <ul>\n                <li>Ha egyszer sem veszítetek, akkor 12 pontot kaptok.</li>\n                <li>1, 2, 3, 4, illetve 5 vereség esetén a kapott pontszám 9-re, 6-ra, 4-re, 3-ra, illetve 2-re csökken.</li>\n                <li>Ennél több vereség esetén is 2 pontot kaptok, ha sikerül teljesítenetek a játékot.</li>\n                <li>Ha 30 perc alatt nem győzitek le kétszer egymás után a gépet, akkor 0 pontot kaptok.</li>\n              </ul>\n            </p>\n            <p>\n              Ha készen álltok, kattintsatok a lenti gombra és onnantól kezdve összesen 30 perc áll rendelkezésetekre.\n            </p>",
+    "pointsNotSettled": "A pontszámotok csak tájékoztató jellegű, a végleges pontszámotokat a beküldött válaszok alapján újraértékeljük.",
+    "relayDescription": "A váltófeladatok rövid szöveges feladatok, melyekre a válasz egy egész szám (legalább 0 és legfeljebb 9999). Minden váltófeladatra maximum 3 tippet adhattok le, egy-egy rossz tipp után az adott feladatra megszerezhető pontszám 1-gyel csökken. Helyes tipp vagy három rossz tipp után megkapjátok a következő feladatot. A váltófeladatokra összesen 60 perc áll rendelkezésre, és összesen 40 pont szerezhető velük hibátlan teljesítés esetén. (Az egyes feladatokra kapható pontszám 3-tól 6-ig terjed.)",
+    "result": "Eredmények",
+    "start": "Kezdjük"
+  },
   "disclaimer": {
-    "welcome": "Kedves <i>{{tname}}</i> csapat, üdvözlünk az online fordulón!",
     "category": "Kategóriátok: <b>{{category}}</b>",
-    "start": "Az online fordulón a csapatoknak önállóan kell dolgozniuk, más emberektől nem kérhetnek segítséget a versenyzési időszak végéig (21:30-ig). A mesterséges intelligencia használata is tilos.",
-    "progress": "Továbbjutás",
-    "progressDescription": "Azok a csapatok, amelyek az online forduló során a megszerezhető {{maxpoints}} pontból legalább {{minpoints}} pontot elérnek, továbbjutnak a helyi fordulóba. (Fenntartjuk a jogot, hogy a ponthatárt esetleg csökkentsük, növelni biztosan nem fogjuk.) Az online fordulón szerzett pontszám nem számít bele a további eredményekbe.",
+    "continue": "Tovább a versenyhez",
     "interface": "A felület",
     "interfaceDescription": "A felület mobilon és gépen is kitölthető, egyszerre akár több eszközzel is bejelentkezhettek.",
     "interfaceDescriptionOfflineMode": "A felület mobilon és gépen is kitölthető. Kérünk bennetek, hogy <b>legfeljebb 1 eszközről</b> töltsétek ki az online fordulót, továbbá <b>ne frissítsétek le az oldalt</b> a verseny során.<br /><small>(Ha mégis frissítitek az oldalt, akkor a verseny újraindul (de az eddigi eredményeitek megmaradnak). Ekkor - minél gyorsabban - menjetek vissza ahhoz a feladathoz, ahol jártatok. Figyeljetek arra, hogy bár az időzítő újraindul a frissítés után, de így is csak az időben beérkezett válaszokat fogjuk figyelembe venni.)</small>",
-    "continue": "Tovább a versenyhez"
+    "progress": "Továbbjutás",
+    "progressDescription": "Azok a csapatok, amelyek az online forduló során a megszerezhető {{maxpoints}} pontból legalább {{minpoints}} pontot elérnek, továbbjutnak a helyi fordulóba. (Fenntartjuk a jogot, hogy a ponthatárt esetleg csökkentsük, növelni biztosan nem fogjuk.) Az online fordulón szerzett pontszám nem számít bele a további eredményekbe.",
+    "start": "Az online fordulón a csapatoknak önállóan kell dolgozniuk, más emberektől nem kérhetnek segítséget a versenyzési időszak végéig (21:30-ig). A mesterséges intelligencia használata is tilos.",
+    "welcome": "Kedves <i>{{tname}}</i> csapat, üdvözlünk az online fordulón!"
   },
-  "chooser": {
-    "finish": {
-      "title": "Vége a versenynek!",
-      "content": "Köszönjük a részvételeteket, reméljük, hogy tetszett nektek a verseny. Kíváncsiak vagyunk a fordulóval kapcsolatos véleményetekre, így kérjük, <a>töltsétek ki ezt az űrlapot</a>. Várhatóan csütörtökig közzétesszük az eredményeket és a továbbjutó csapatok listáját, és erről emailben is fogunk nektek értesítést küldeni.",
-      "final": "Végső pontszám"
-    },
-    "gameDescriptionHtml": "<p>Ebben a feladatban egy kétszemélyes stratégiás játékot játszhattok, ahol az egyik játékos Ti lesztek, a másik játékos pedig a gép. Győzzétek le a gépet <b>kétszer egymás után</b> ebben a játékban! A kezdő helyzet ismeretében Ti dönthetitek el, hogy a kezdő vagy a második játékos bőrébe szeretnétek bújni.</p>         \n            <p>A sikeres teljesítésért az alábbiak szerint kaptok pontot:\n              <ul>\n                <li>Ha egyszer sem veszítetek, akkor 12 pontot kaptok.</li>\n                <li>1, 2, 3, 4, illetve 5 vereség esetén a kapott pontszám 9-re, 6-ra, 4-re, 3-ra, illetve 2-re csökken.</li>\n                <li>Ennél több vereség esetén is 2 pontot kaptok, ha sikerül teljesítenetek a játékot.</li>\n                <li>Ha 30 perc alatt nem győzitek le kétszer egymás után a gépet, akkor 0 pontot kaptok.</li>\n              </ul>\n            </p>\n            <p>\n              Ha készen álltok, kattintsatok a lenti gombra és onnantól kezdve összesen 30 perc áll rendelkezésetekre.\n            </p>",
-    "relayDescription": "A váltófeladatok rövid szöveges feladatok, melyekre a válasz egy egész szám (legalább 0 és legfeljebb 9999). Minden váltófeladatra maximum 3 tippet adhattok le, egy-egy rossz tipp után az adott feladatra megszerezhető pontszám 1-gyel csökken. Helyes tipp vagy három rossz tipp után megkapjátok a következő feladatot. A váltófeladatokra összesen 60 perc áll rendelkezésre, és összesen 40 pont szerezhető velük hibátlan teljesítés esetén. (Az egyes feladatokra kapható pontszám 3-tól 6-ig terjed.)",
-    "filledAt": "Kitöltve ekkor",
-    "achievedPoint": "Elért pontszám",
-    "start": "Kezdjük",
-    "result": "Eredmények",
-    "pointsNotSettled": "A pontszámotok csak tájékoztató jellegű, a végleges pontszámotokat a beküldött válaszok alapján újraértékeljük."
-  },
-  "relay": {
-    "endTable": {
-      "task": "Feladat",
-      "point": "Pontszám",
-      "try": "{{count}}. próbálkozásra",
-      "wrong": "Hibás válasz",
-      "all": "Összpontszám",
-      "back": "Vissza a versenyhez",
-      "reminder": "Ne feledkezzetek meg a stratégiás játékról, ha azzal még nem játszottatok!"
-    },
-    "error": {
-      "duplicate": "Ezt a választ már próbáltátok",
-      "integer": "Egész számot kell írni",
-      "type": "Számot kell írnod",
-      "range": "A megoldás 0 és 9999 között van",
-      "badCategory": "ROSSZ KATEGÓRIA",
-      "empty": "Nem írtál semmilyen választ!"
-    },
-    "goodGuess": "A válasz helyes volt",
-    "wrongGuess": "A válasz sajnos nem volt jó",
-    "name": "Váltófeladatok",
-    "guess": "Tipp:",
-    "send": "Küldés",
-    "guessNum": "{{guessnum}}. próba:",
-    "task": "{{num}}. feladat ({{maxpoints}})",
-    "taskImage": "A feladathoz tartozó kép (ha nem töltött be, próbáld meg frissíteni az oldalt!)"
+  "error": {
+    "notFound": "Ez az oldal nem található",
+    "unexpected": "Váratlan hiba történt"
   },
   "general": {
     "loading": "Játék vagy feladat betöltése…",
@@ -67,57 +44,80 @@
     "title": "XIX. Dürer Verseny"
   },
   "login": {
-    "greeting": "Kedves Versenyző!",
-    "beforeTitle": "Üdvözlünk a ",
     "afterTitle": " online fordulójának felületén.",
-    "loginInstruction": "Belépéshez nézd meg az emailjeidet, és üsd be az ott található kódot ide:",
-    "fallback": "Ha nem találjátok az emailt, akkor írjatok nekünk a verseny [K] durerinfo [P] hu email címre.",
-    "loginButton": "Belépés",
+    "beforeTitle": "Üdvözlünk a ",
     "error": {
       "empty": "Nem adtál meg kódot!",
       "wrongid": "Rossz belépési kód!"
-    }
+    },
+    "fallback": "Ha nem találjátok az emailt, akkor írjatok nekünk a verseny [K] durerinfo [P] hu email címre.",
+    "greeting": "Kedves Versenyző!",
+    "loginButton": "Belépés",
+    "loginInstruction": "Belépéshez nézd meg az emailjeidet, és üsd be az ott található kódot ide:"
   },
-  "waitingRoom": {
-    "soon": "Az online forduló hamarosan kezdődik!",
-    "remainingStart": "Még",
-    "remainingEnd": "van hátra kezdésig!",
-    "instruction": "A verseny kezdetekor automatikusan átirányításra kerültök a verseny felületre."
+  "relay": {
+    "endTable": {
+      "all": "Összpontszám",
+      "back": "Vissza a versenyhez",
+      "point": "Pontszám",
+      "reminder": "Ne feledkezzetek meg a stratégiás játékról, ha azzal még nem játszottatok!",
+      "task": "Feladat",
+      "try": "{{count}}. próbálkozásra",
+      "wrong": "Hibás válasz"
+    },
+    "error": {
+      "badCategory": "ROSSZ KATEGÓRIA",
+      "duplicate": "Ezt a választ már próbáltátok",
+      "empty": "Nem írtál semmilyen választ!",
+      "integer": "Egész számot kell írni",
+      "range": "A megoldás 0 és 9999 között van",
+      "type": "Számot kell írnod"
+    },
+    "goodGuess": "A válasz helyes volt",
+    "guess": "Tipp:",
+    "guessNum": "{{guessnum}}. próba:",
+    "name": "Váltófeladatok",
+    "send": "Küldés",
+    "task": "{{num}}. feladat ({{maxpoints}})",
+    "taskImage": "A feladathoz tartozó kép (ha nem töltött be, próbáld meg frissíteni az oldalt!)",
+    "wrongGuess": "A válasz sajnos nem volt jó"
   },
   "strategy": {
-    "notSupported": "NEM TÁMOGATOTT JÁTÉKÁLLAPOT",
-    "name": "Stratégiás játék",
-    "description": "Feladat leírása",
-    "instructions": "Tudnivalók",
-    "instructionDescription": "Az „Új próbajáték kezdése” gombra kattintva próbajáték indul, ami a pontozásba nem számít bele. Bátran kérjetek próbajátékot, hiszen ezzel tudjátok tesztelni, hogy jól értitek-e a játék működését. Az „Új éles játék kezdése” gombra kattintva indul a valódi játék, ami már pontért megy.",
-    "realResults": "Éles játékok eddigi eredményei: {{wins}}, {{defeats}}",
-    "wins": "{{count}} győzelem",
     "defeats": "{{count}} vereség",
-    "testGameButton": "Új próbajáték kezdése",
-    "realGameButton": "Új éles játék kezdése",
-    "firstPlayer": "Kezdő leszek",
-    "secondPlayer": "Második leszek",
+    "description": "Feladat leírása",
     "endTable": {
       "all": "Összpontszám",
       "gained": "Szerzett pontok",
       "tries": "Próbálkozások száma"
     },
+    "firstPlayer": "Kezdő leszek",
     "guide": {
-      "newGame": "Kezdj új játékot!",
-      "ifFirstPlayer": "Válaszd ki, hogy első vagy második játékos akarsz-e lenni.",
-      "yourTurn": "Most Te jössz!",
-      "waitingForServer": "Várakozás a szerverre...",
-      "realGameWin": "Gratulálok, nyertetek! Verjétek meg még következőleg is a gépet a teljes győzelemhez!",
-      "testGameWin": "Gratulálok, a próbajátékban nyertetek!",
+      "actions": "Akciók",
       "botWins": "Sajnos a gép nyert.",
       "endOfGame": "A játék végetért.",
+      "ifFirstPlayer": "Válaszd ki, hogy első vagy második játékos akarsz-e lenni.",
       "liveStarted": "Éles játék elindítva.",
+      "newGame": "Kezdj új játékot!",
+      "realGameWin": "Gratulálok, nyertetek! Verjétek meg még következőleg is a gépet a teljes győzelemhez!",
+      "testGameWin": "Gratulálok, a próbajátékban nyertetek!",
       "testStarted": "Próbajáték elindítva.",
-      "actions": "Akciók"
-    }
+      "waitingForServer": "Várakozás a szerverre...",
+      "yourTurn": "Most Te jössz!"
+    },
+    "instructionDescription": "Az „Új próbajáték kezdése” gombra kattintva próbajáték indul, ami a pontozásba nem számít bele. Bátran kérjetek próbajátékot, hiszen ezzel tudjátok tesztelni, hogy jól értitek-e a játék működését. Az „Új éles játék kezdése” gombra kattintva indul a valódi játék, ami már pontért megy.",
+    "instructions": "Tudnivalók",
+    "name": "Stratégiás játék",
+    "notSupported": "NEM TÁMOGATOTT JÁTÉKÁLLAPOT",
+    "realGameButton": "Új éles játék kezdése",
+    "realResults": "Éles játékok eddigi eredményei: {{wins}}, {{defeats}}",
+    "secondPlayer": "Második leszek",
+    "testGameButton": "Új próbajáték kezdése",
+    "wins": "{{count}} győzelem"
   },
-  "error": {
-    "unexpected": "Váratlan hiba történt",
-    "notFound": "Ez az oldal nem található"
+  "waitingRoom": {
+    "instruction": "A verseny kezdetekor automatikusan átirányításra kerültök a verseny felületre.",
+    "remainingEnd": "van hátra kezdésig!",
+    "remainingStart": "Még",
+    "soon": "Az online forduló hamarosan kezdődik!"
   }
 }

--- a/packages/common-frontend/public/locales/hu/translation.json
+++ b/packages/common-frontend/public/locales/hu/translation.json
@@ -1,9 +1,5 @@
 {
   "translation": {
-    "languages": {
-      "en": "Angol",
-      "hu": "Magyar"
-    },
     "disclaimer": {
       "welcome": "Kedves <i>{{tname}}</i> csapat, üdvözlünk az online fordulón!",
       "category": "Kategóriátok: <b>{{category}}</b>",
@@ -55,13 +51,13 @@
       "guess": "Tipp:",
       "send": "Küldés",
       "guessNum": "{{guessnum}}. próba:",
+      "task": "{{num}}. feladat ({{maxpoints}})",
       "taskImage": "A feladathoz tartozó kép (ha nem töltött be, próbáld meg frissíteni az oldalt!)"
     },
     "general": {
       "loading": "Játék vagy feladat betöltése…",
+      "points": "{{count}} pont",
       "remainingTime": "Hátralevő idő",
-      "task": "feladat",
-      "point": "pont",
       "returnHome": "Vissza a főoldalra",
       "warning": {
         "timeNotMatch": "A számítógép órája nincs szinkronban a szerver órájával, a jelzett hátralevő idő nem tökéletes, az oldal újra töltése megoldhatja a problémát",
@@ -114,7 +110,7 @@
         "ifFirstPlayer": "Válaszd ki, hogy első vagy második játékos akarsz-e lenni.",
         "yourTurn": "Most Te jössz!",
         "waitingForServer": "Várakozás a szerverre...",
-        "realGameWin": "Gratulálok, nyertetek! Verjétek meg még egyszer a gépet!",
+        "realGameWin": "Gratulálok, nyertetek! Verjétek meg még következőleg is a gépet a teljes győzelemhez!",
         "testGameWin": "Gratulálok, a próbajátékban nyertetek!",
         "botWins": "Sajnos a gép nyert.",
         "endOfGame": "A játék végetért.",

--- a/packages/common-frontend/public/locales/hu/translation.json
+++ b/packages/common-frontend/public/locales/hu/translation.json
@@ -1,128 +1,123 @@
 {
-  "translation": {
-    "disclaimer": {
-      "welcome": "Kedves <i>{{tname}}</i> csapat, üdvözlünk az online fordulón!",
-      "category": "Kategóriátok: <b>{{category}}</b>",
-      "start": "Az online fordulón a csapatoknak önállóan kell dolgozniuk, más emberektől nem kérhetnek segítséget a versenyzési időszak végéig (21:30-ig). A mesterséges intelligencia használata is tilos.",
-      "progress": "Továbbjutás",
-      "progressDescription": "Azok a csapatok, amelyek az online forduló során a megszerezhető {{maxpoints}} pontból legalább {{minpoints}} pontot elérnek, továbbjutnak a helyi fordulóba. (Fenntartjuk a jogot, hogy a ponthatárt esetleg csökkentsük, növelni biztosan nem fogjuk.) Az online fordulón szerzett pontszám nem számít bele a további eredményekbe.",
-      "interface": "A felület",
-      "interfaceDescription": "A felület mobilon és gépen is kitölthető, egyszerre akár több eszközzel is bejelentkezhettek.",
-      "interfaceDescriptionOfflineMode": "A felület mobilon és gépen is kitölthető. Kérünk bennetek, hogy <b>legfeljebb 1 eszközről</b> töltsétek ki az online fordulót, továbbá <b>ne frissítsétek le az oldalt</b> a verseny során.<br /><small>(Ha mégis frissítitek az oldalt, akkor a verseny újraindul (de az eddigi eredményeitek megmaradnak). Ekkor - minél gyorsabban - menjetek vissza ahhoz a feladathoz, ahol jártatok. Figyeljetek arra, hogy bár az időzítő újraindul a frissítés után, de így is csak az időben beérkezett válaszokat fogjuk figyelembe venni.)</small>",
-      "continue": "Tovább a versenyhez"
+  "disclaimer": {
+    "welcome": "Kedves <i>{{tname}}</i> csapat, üdvözlünk az online fordulón!",
+    "category": "Kategóriátok: <b>{{category}}</b>",
+    "start": "Az online fordulón a csapatoknak önállóan kell dolgozniuk, más emberektől nem kérhetnek segítséget a versenyzési időszak végéig (21:30-ig). A mesterséges intelligencia használata is tilos.",
+    "progress": "Továbbjutás",
+    "progressDescription": "Azok a csapatok, amelyek az online forduló során a megszerezhető {{maxpoints}} pontból legalább {{minpoints}} pontot elérnek, továbbjutnak a helyi fordulóba. (Fenntartjuk a jogot, hogy a ponthatárt esetleg csökkentsük, növelni biztosan nem fogjuk.) Az online fordulón szerzett pontszám nem számít bele a további eredményekbe.",
+    "interface": "A felület",
+    "interfaceDescription": "A felület mobilon és gépen is kitölthető, egyszerre akár több eszközzel is bejelentkezhettek.",
+    "interfaceDescriptionOfflineMode": "A felület mobilon és gépen is kitölthető. Kérünk bennetek, hogy <b>legfeljebb 1 eszközről</b> töltsétek ki az online fordulót, továbbá <b>ne frissítsétek le az oldalt</b> a verseny során.<br /><small>(Ha mégis frissítitek az oldalt, akkor a verseny újraindul (de az eddigi eredményeitek megmaradnak). Ekkor - minél gyorsabban - menjetek vissza ahhoz a feladathoz, ahol jártatok. Figyeljetek arra, hogy bár az időzítő újraindul a frissítés után, de így is csak az időben beérkezett válaszokat fogjuk figyelembe venni.)</small>",
+    "continue": "Tovább a versenyhez"
+  },
+  "chooser": {
+    "finish": {
+      "title": "Vége a versenynek!",
+      "content": "Köszönjük a részvételeteket, reméljük, hogy tetszett nektek a verseny. Kíváncsiak vagyunk a fordulóval kapcsolatos véleményetekre, így kérjük, <a>töltsétek ki ezt az űrlapot</a>. Várhatóan csütörtökig közzétesszük az eredményeket és a továbbjutó csapatok listáját, és erről emailben is fogunk nektek értesítést küldeni.",
+      "final": "Végső pontszám"
     },
-    "chooser": {
-      "finish": {
-        "title": "Vége a versenynek!",
-        "content": "Köszönjük a részvételeteket, reméljük, hogy tetszett nektek a verseny. Kíváncsiak vagyunk a fordulóval kapcsolatos véleményetekre, így kérjük, <a>töltsétek ki ezt az űrlapot</a>. Várhatóan csütörtökig közzétesszük az eredményeket és a továbbjutó csapatok listáját, és erről emailben is fogunk nektek értesítést küldeni.",
-        "final": "Végső pontszám"
-      },
-      "gameDescriptionHtml": "<p>Ebben a feladatban egy kétszemélyes stratégiás játékot játszhattok, ahol az egyik játékos Ti lesztek, a másik játékos pedig a gép. Győzzétek le a gépet <b>kétszer egymás után</b> ebben a játékban! A kezdő helyzet ismeretében Ti dönthetitek el, hogy a kezdő vagy a második játékos bőrébe szeretnétek bújni.</p>         \n            <p>A sikeres teljesítésért az alábbiak szerint kaptok pontot:\n              <ul>\n                <li>Ha egyszer sem veszítetek, akkor 12 pontot kaptok.</li>\n                <li>1, 2, 3, 4, illetve 5 vereség esetén a kapott pontszám 9-re, 6-ra, 4-re, 3-ra, illetve 2-re csökken.</li>\n                <li>Ennél több vereség esetén is 2 pontot kaptok, ha sikerül teljesítenetek a játékot.</li>\n                <li>Ha 30 perc alatt nem győzitek le kétszer egymás után a gépet, akkor 0 pontot kaptok.</li>\n              </ul>\n            </p>\n            <p>\n              Ha készen álltok, kattintsatok a lenti gombra és onnantól kezdve összesen 30 perc áll rendelkezésetekre.\n            </p>",
-      "relayDescription": "A váltófeladatok rövid szöveges feladatok, melyekre a válasz egy egész szám (legalább 0 és legfeljebb 9999). Minden váltófeladatra maximum 3 tippet adhattok le, egy-egy rossz tipp után az adott feladatra megszerezhető pontszám 1-gyel csökken. Helyes tipp vagy három rossz tipp után megkapjátok a következő feladatot. A váltófeladatokra összesen 60 perc áll rendelkezésre, és összesen 40 pont szerezhető velük hibátlan teljesítés esetén. (Az egyes feladatokra kapható pontszám 3-tól 6-ig terjed.)",
-      "filledAt": "Kitöltve ekkor",
-      "achievedPoint": "Elért pontszám",
-      "start": "Kezdjük",
-      "result": "Eredmények",
-      "pointsNotSettled": "A pontszámotok csak tájékoztató jellegű, a végleges pontszámotokat a beküldött válaszok alapján újraértékeljük."
-    },
-    "relay": {
-      "endTable": {
-        "title": "A váltó befejeződött",
-        "task": "Feladat",
-        "point": "Pontszám",
-        "try": "{{count}}. próbálkozásra",
-        "wrong": "Hibás válasz",
-        "all": "Összpontszám",
-        "pointsGained": "pontot szereztél",
-        "back": "Vissza a versenyhez",
-        "reminder": "Ne feledkezzetek meg a stratégiás játékról, ha azzal még nem játszottatok!"
-      },
-      "error": {
-        "duplicate": "Ezt a választ már próbáltátok",
-        "integer": "Egész számot kell írni",
-        "type": "Számot kell írnod",
-        "range": "A megoldás 0 és 9999 között van",
-        "badCategory": "ROSSZ KATEGÓRIA",
-        "empty": "Nem írtál semmilyen választ!"
-      },
-      "goodGuess": "A válasz helyes volt",
-      "wrongGuess": "A válasz sajnos nem volt jó",
-      "name": "Váltófeladatok",
-      "guess": "Tipp:",
-      "send": "Küldés",
-      "guessNum": "{{guessnum}}. próba:",
-      "task": "{{num}}. feladat ({{maxpoints}})",
-      "taskImage": "A feladathoz tartozó kép (ha nem töltött be, próbáld meg frissíteni az oldalt!)"
-    },
-    "general": {
-      "loading": "Játék vagy feladat betöltése…",
-      "points": "{{count}} pont",
-      "remainingTime": "Hátralevő idő",
-      "returnHome": "Vissza a főoldalra",
-      "warning": {
-        "timeNotMatch": "A számítógép órája nincs szinkronban a szerver órájával, a jelzett hátralevő idő nem tökéletes, az oldal újra töltése megoldhatja a problémát",
-        "timeNotReal": "Az óra csak tájékoztató jellegű. Más eszközökön és böngészőkben más időt fogtok látni, de így is csak az időben beérkezett válaszokat fogjuk figyelembe venni."
-      }
-    },
-    "header": {
-      "logout": "kilépés",
-      "subtitle": "Online forduló",
-      "title": "XIX. Dürer Verseny"
-    },
-    "login": {
-      "greeting": "Kedves Versenyző!",
-      "beforeTitle": "Üdvözlünk a ",
-      "afterTitle": " online fordulójának felületén.",
-      "loginInstruction": "Belépéshez nézd meg az emailjeidet, és üsd be az ott található kódot ide:",
-      "fallback": "Ha nem találjátok az emailt, akkor írjatok nekünk a verseny [K] durerinfo [P] hu email címre.",
-      "loginButton": "Belépés",
-      "error": { 
-        "empty": "Nem adtál meg kódot!",
-        "wrongid": "Rossz belépési kód!"
-      }
-    },
-    "waitingRoom": {
-      "soon": "Az online forduló hamarosan kezdődik!",
-      "remainingStart": "Még",
-      "remainingEnd": "van hátra kezdésig!",
-      "instruction": "A verseny kezdetekor automatikusan átirányításra kerültök a verseny felületre."
-    },
-    "strategy": {
-      "notSupported": "NEM TÁMOGATOTT JÁTÉKÁLLAPOT",
-      "name": "Stratégiás játék",
-      "description": "Feladat leírása",
-      "instructions": "Tudnivalók",
-      "instructionDescription": "Az „Új próbajáték kezdése” gombra kattintva próbajáték indul, ami a pontozásba nem számít bele. Bátran kérjetek próbajátékot, hiszen ezzel tudjátok tesztelni, hogy jól értitek-e a játék működését. Az „Új éles játék kezdése” gombra kattintva indul a valódi játék, ami már pontért megy.",
-      "realResults": "Éles játékok eddigi eredményei: {{wins}}, {{defeats}}",
-      "wins": "{{count}} győzelem",
-      "defeats": "{{count}} vereség",
-      "testGameButton": "Új próbajáték kezdése",
-      "realGameButton": "Új éles játék kezdése",
-      "firstPlayer": "Kezdő leszek",
-      "secondPlayer": "Második leszek",
-      "endTable": {
-        "all": "Összpontszám",
-        "gained": "Szerzett pontok",
-        "tries": "Próbálkozások száma"
-      },
-      "guide": {
-        "newGame": "Kezdj új játékot!",
-        "ifFirstPlayer": "Válaszd ki, hogy első vagy második játékos akarsz-e lenni.",
-        "yourTurn": "Most Te jössz!",
-        "waitingForServer": "Várakozás a szerverre...",
-        "realGameWin": "Gratulálok, nyertetek! Verjétek meg még következőleg is a gépet a teljes győzelemhez!",
-        "testGameWin": "Gratulálok, a próbajátékban nyertetek!",
-        "botWins": "Sajnos a gép nyert.",
-        "endOfGame": "A játék végetért.",
-        "liveStarted": "Éles játék elindítva.",
-        "testStarted": "Próbajáték elindítva.",
-        "results": "Eredmények",
-        "actions": "Akciók"
-      }
+    "gameDescriptionHtml": "<p>Ebben a feladatban egy kétszemélyes stratégiás játékot játszhattok, ahol az egyik játékos Ti lesztek, a másik játékos pedig a gép. Győzzétek le a gépet <b>kétszer egymás után</b> ebben a játékban! A kezdő helyzet ismeretében Ti dönthetitek el, hogy a kezdő vagy a második játékos bőrébe szeretnétek bújni.</p>         \n            <p>A sikeres teljesítésért az alábbiak szerint kaptok pontot:\n              <ul>\n                <li>Ha egyszer sem veszítetek, akkor 12 pontot kaptok.</li>\n                <li>1, 2, 3, 4, illetve 5 vereség esetén a kapott pontszám 9-re, 6-ra, 4-re, 3-ra, illetve 2-re csökken.</li>\n                <li>Ennél több vereség esetén is 2 pontot kaptok, ha sikerül teljesítenetek a játékot.</li>\n                <li>Ha 30 perc alatt nem győzitek le kétszer egymás után a gépet, akkor 0 pontot kaptok.</li>\n              </ul>\n            </p>\n            <p>\n              Ha készen álltok, kattintsatok a lenti gombra és onnantól kezdve összesen 30 perc áll rendelkezésetekre.\n            </p>",
+    "relayDescription": "A váltófeladatok rövid szöveges feladatok, melyekre a válasz egy egész szám (legalább 0 és legfeljebb 9999). Minden váltófeladatra maximum 3 tippet adhattok le, egy-egy rossz tipp után az adott feladatra megszerezhető pontszám 1-gyel csökken. Helyes tipp vagy három rossz tipp után megkapjátok a következő feladatot. A váltófeladatokra összesen 60 perc áll rendelkezésre, és összesen 40 pont szerezhető velük hibátlan teljesítés esetén. (Az egyes feladatokra kapható pontszám 3-tól 6-ig terjed.)",
+    "filledAt": "Kitöltve ekkor",
+    "achievedPoint": "Elért pontszám",
+    "start": "Kezdjük",
+    "result": "Eredmények",
+    "pointsNotSettled": "A pontszámotok csak tájékoztató jellegű, a végleges pontszámotokat a beküldött válaszok alapján újraértékeljük."
+  },
+  "relay": {
+    "endTable": {
+      "task": "Feladat",
+      "point": "Pontszám",
+      "try": "{{count}}. próbálkozásra",
+      "wrong": "Hibás válasz",
+      "all": "Összpontszám",
+      "back": "Vissza a versenyhez",
+      "reminder": "Ne feledkezzetek meg a stratégiás játékról, ha azzal még nem játszottatok!"
     },
     "error": {
-      "unexpected": "Váratlan hiba történt",
-      "notFound": "Ez az oldal nem található"
+      "duplicate": "Ezt a választ már próbáltátok",
+      "integer": "Egész számot kell írni",
+      "type": "Számot kell írnod",
+      "range": "A megoldás 0 és 9999 között van",
+      "badCategory": "ROSSZ KATEGÓRIA",
+      "empty": "Nem írtál semmilyen választ!"
+    },
+    "goodGuess": "A válasz helyes volt",
+    "wrongGuess": "A válasz sajnos nem volt jó",
+    "name": "Váltófeladatok",
+    "guess": "Tipp:",
+    "send": "Küldés",
+    "guessNum": "{{guessnum}}. próba:",
+    "task": "{{num}}. feladat ({{maxpoints}})",
+    "taskImage": "A feladathoz tartozó kép (ha nem töltött be, próbáld meg frissíteni az oldalt!)"
+  },
+  "general": {
+    "loading": "Játék vagy feladat betöltése…",
+    "points": "{{count}} pont",
+    "remainingTime": "Hátralevő idő",
+    "returnHome": "Vissza a főoldalra",
+    "warning": {
+      "timeNotMatch": "A számítógép órája nincs szinkronban a szerver órájával, a jelzett hátralevő idő nem tökéletes, az oldal újra töltése megoldhatja a problémát",
+      "timeNotReal": "Az óra csak tájékoztató jellegű. Más eszközökön és böngészőkben más időt fogtok látni, de így is csak az időben beérkezett válaszokat fogjuk figyelembe venni."
     }
+  },
+  "header": {
+    "logout": "kilépés",
+    "subtitle": "Online forduló",
+    "title": "XIX. Dürer Verseny"
+  },
+  "login": {
+    "greeting": "Kedves Versenyző!",
+    "beforeTitle": "Üdvözlünk a ",
+    "afterTitle": " online fordulójának felületén.",
+    "loginInstruction": "Belépéshez nézd meg az emailjeidet, és üsd be az ott található kódot ide:",
+    "fallback": "Ha nem találjátok az emailt, akkor írjatok nekünk a verseny [K] durerinfo [P] hu email címre.",
+    "loginButton": "Belépés",
+    "error": {
+      "empty": "Nem adtál meg kódot!",
+      "wrongid": "Rossz belépési kód!"
+    }
+  },
+  "waitingRoom": {
+    "soon": "Az online forduló hamarosan kezdődik!",
+    "remainingStart": "Még",
+    "remainingEnd": "van hátra kezdésig!",
+    "instruction": "A verseny kezdetekor automatikusan átirányításra kerültök a verseny felületre."
+  },
+  "strategy": {
+    "notSupported": "NEM TÁMOGATOTT JÁTÉKÁLLAPOT",
+    "name": "Stratégiás játék",
+    "description": "Feladat leírása",
+    "instructions": "Tudnivalók",
+    "instructionDescription": "Az „Új próbajáték kezdése” gombra kattintva próbajáték indul, ami a pontozásba nem számít bele. Bátran kérjetek próbajátékot, hiszen ezzel tudjátok tesztelni, hogy jól értitek-e a játék működését. Az „Új éles játék kezdése” gombra kattintva indul a valódi játék, ami már pontért megy.",
+    "realResults": "Éles játékok eddigi eredményei: {{wins}}, {{defeats}}",
+    "wins": "{{count}} győzelem",
+    "defeats": "{{count}} vereség",
+    "testGameButton": "Új próbajáték kezdése",
+    "realGameButton": "Új éles játék kezdése",
+    "firstPlayer": "Kezdő leszek",
+    "secondPlayer": "Második leszek",
+    "endTable": {
+      "all": "Összpontszám",
+      "gained": "Szerzett pontok",
+      "tries": "Próbálkozások száma"
+    },
+    "guide": {
+      "newGame": "Kezdj új játékot!",
+      "ifFirstPlayer": "Válaszd ki, hogy első vagy második játékos akarsz-e lenni.",
+      "yourTurn": "Most Te jössz!",
+      "waitingForServer": "Várakozás a szerverre...",
+      "realGameWin": "Gratulálok, nyertetek! Verjétek meg még következőleg is a gépet a teljes győzelemhez!",
+      "testGameWin": "Gratulálok, a próbajátékban nyertetek!",
+      "botWins": "Sajnos a gép nyert.",
+      "endOfGame": "A játék végetért.",
+      "liveStarted": "Éles játék elindítva.",
+      "testStarted": "Próbajáték elindítva.",
+      "actions": "Akciók"
+    }
+  },
+  "error": {
+    "unexpected": "Váratlan hiba történt",
+    "notFound": "Ez az oldal nem található"
   }
 }

--- a/packages/common-frontend/src/client/components/Admin.tsx
+++ b/packages/common-frontend/src/client/components/Admin.tsx
@@ -90,202 +90,205 @@ export function Admin(props: {teamId?: string}) {
         </IconButton>
         <Stack sx={{fontSize:"32px", textAlign: "center"}}>Admin felület </Stack>
       </Stack>
-      {adminPageOpen && teamFromPath && <TeamDetailDialog data={teamFromPath} setConfirmDialog={setConfirmDialog}/>}
-      {adminPageOpen && !teamFromPath && <Stack sx={{
-        height: "635px",
-      }}>
-        {data && <DataGrid columns={[
-          {
-            field: 'id',
-            headerName: 'ID',
-            width: 75,
-            editable: false,
-          },
-          {
-            field: 'teamName',
-            headerName: 'Csapatnév',
-            width: 200,
-            editable: false,
-          },
-          {
-            field: 'category',
-            headerName: 'Kategória',
-            width: 100,
-            editable: false,
-          },
-          {
-            field: 'pageState',
-            headerName: 'Állapot',
-            width: 150,
-            editable: false,
-          },
-          {
-            field: 'other',
-            headerName: 'Egyéb',
-            width: 250,
-            editable: false,
-          },
-          {
-            field: 'relayMatchState',
-            headerName: 'Relay',
-            width: 120,
-            editable: false,
-          },
-          {
-            field: 'strategyMatchState',
-            headerName: 'Strategy',
-            width: 120,
-            editable: false,
-          },
-          {
-            field: 'view',
-            width: 170,
-            headerName: '',
-            renderCell: (renderData) => {
-              return (
-                <Button
-                  color='primary'
-                  variant='contained'
-                  onClick={() => {setSelectedRow(renderData.row as TeamModelDto)}}>
-                    Szerkesztés
-                </Button>
-              )
-            }
-          },
-          {
-            field: 'view_tab',
-            width: 170,
-            headerName: '',
-            renderCell: (renderData) => {
-              return (
-                <Button
-                  color='primary'
-                  variant='contained'
-                  onClick={()=>{
-                    window.open("/admin/"+renderData.row.teamId, '_blank', 'noopener,noreferrer')
-                  }}>
-                    + új tab
-                </Button>
-              )
-            }
-          }
-        ]}
-        rows={data.map((a)=>{
-          return {
-            id: a.teamId,
-            relayMatchState: a.relayMatch.state,
-            strategyMatchState: a.strategyMatch.state,
-             ...a,
-          };
-        })}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 10,
+      {adminPageOpen && <>
+        {teamFromPath && <TeamDetailDialog data={teamFromPath} setConfirmDialog={setConfirmDialog}/>}
+        {!teamFromPath && <Stack sx={{
+          height: "635px",
+        }}>
+          {data && <DataGrid columns={[
+            {
+              field: 'id',
+              headerName: 'ID',
+              width: 75,
+              editable: false,
             },
-          },
-          columns: {
-            columnVisibilityModel: {
-              other: false,
+            {
+              field: 'teamName',
+              headerName: 'Csapatnév',
+              width: 200,
+              editable: false,
             },
-          },
-        }}
-        pageSizeOptions={[10, 25, 50]}
-        sx={{
-          height: "auto",
-        }}
-        />}
-      </Stack>}
-      {adminPageOpen && !teamFromPath && data && <Stack sx={{padding: "10px"}}>
-        idő hozzáadása minden aktív játékosnak:
-        <Form
-        initialValues={{ time: '' }}
-        validationSchema={Yup.object().shape({
-          time: Yup.number()
-            .integer('Egész számot kell írni')
-            .typeError('Számot kell írni')
-            .required('Nincs megadva érték')
-          })}
-        onSubmit={async (values) => { 
-          setConfirmDialog({
-            text: `Erősítsd meg, hogy minden aktuális csapatnak meg akarod növelni az idejét ${values.time} perccel`,
-            confirm: async () => {
-              try {
-                data?.forEach(async a=>{
-                  if(a.relayMatch.state === "IN PROGRESS") {
-                    await addMinutes(a.relayMatch.matchID, values.time);
-                  }
-                  if(a.strategyMatch.state === "IN PROGRESS") {
-                    await addMinutes(a.strategyMatch.matchID, values.time);
-                  }
-                })
-                enqueueSnackbar("Sikeres művelet", { variant: 'success' });
-              } catch (e: unknown) {
-                const message = e instanceof Error ? e.message : "Váratlan hiba történt";
-                enqueueSnackbar(message, { variant: 'error' });
+            {
+              field: 'category',
+              headerName: 'Kategória',
+              width: 100,
+              editable: false,
+            },
+            {
+              field: 'pageState',
+              headerName: 'Állapot',
+              width: 150,
+              editable: false,
+            },
+            {
+              field: 'other',
+              headerName: 'Egyéb',
+              width: 250,
+              editable: false,
+            },
+            {
+              field: 'relayMatchState',
+              headerName: 'Relay',
+              width: 120,
+              editable: false,
+            },
+            {
+              field: 'strategyMatchState',
+              headerName: 'Strategy',
+              width: 120,
+              editable: false,
+            },
+            {
+              field: 'view',
+              width: 170,
+              headerName: '',
+              renderCell: (renderData) => {
+                return (
+                  <Button
+                    color='primary'
+                    variant='contained'
+                    onClick={() => {setSelectedRow(renderData.row as TeamModelDto)}}>
+                      Szerkesztés
+                  </Button>
+                )
               }
             },
-          })
-        }}>
-        <Stack sx={{display: "flex", flexDirection: "row", margin: "15px"}}>
-        <Field
-          name="time"
-        >
-        {
-          ({field}: FieldProps<string | number>) => <input
-            {...field}
-            className="text-input"
-            placeholder="perc"
-            style={{
-              width: '200px',
-              borderWidth: '2px',
-              borderColor: theme.palette.primary.main,
-            }}
-          />
-        }</Field>
-        <Button sx={{
-          width: '150px',
-          alignSelf: 'center',
-          textTransform: 'none',
-        }} variant='contained' color='primary' type="submit">
-          hozzáadás
-        </Button>
-        </Stack>
-        <ErrorMessage name="time"/><ErrorMessage name="time" render={msg => (
-          <Stack sx={{ color: 'red', fontSize: '0.875rem' }}>
-            {msg}
-          </Stack>
-        )}/>
-      </Form>
-      </Stack>}
-      {adminPageOpen && !teamFromPath && data &&
-        <Button
-          color="error"
-          variant="contained"
-          sx={{ margin: '10px 0', maxWidth: 300 }}
-          onClick={() => {
+            {
+              field: 'view_tab',
+              width: 170,
+              headerName: '',
+              renderCell: (renderData) => {
+                return (
+                  <Button
+                    color='primary'
+                    variant='contained'
+                    onClick={()=>{
+                      window.open("/admin/"+renderData.row.teamId, '_blank', 'noopener,noreferrer')
+                    }}>
+                      + új tab
+                  </Button>
+                )
+              }
+            }
+          ]}
+          rows={data.map((a)=>{
+            return {
+              id: a.teamId,
+              relayMatchState: a.relayMatch.state,
+              strategyMatchState: a.strategyMatch.state,
+              ...a,
+            };
+          })}
+          initialState={{
+            pagination: {
+              paginationModel: {
+                pageSize: 10,
+              },
+            },
+            columns: {
+              columnVisibilityModel: {
+                other: false,
+              },
+            },
+          }}
+          pageSizeOptions={[10, 25, 50]}
+          sx={{
+            height: "auto",
+          }}
+          />}
+        </Stack>}
+        {!teamFromPath && data && <Stack sx={{padding: "10px"}}>
+          idő hozzáadása minden aktív játékosnak:
+          <Form
+          initialValues={{ time: '' }}
+          validationSchema={Yup.object().shape({
+            time: Yup.number()
+              .integer('Egész számot kell írni')
+              .typeError('Számot kell írni')
+              .required('Nincs megadva érték')
+            })}
+          onSubmit={async (values) => { 
             setConfirmDialog({
-              text: 'Biztosan törlöd az összes csapatot? Ez a művelet nem visszavonható!',
+              text: `Erősítsd meg, hogy minden aktuális csapatnak meg akarod növelni az idejét ${values.time} perccel`,
               confirm: async () => {
                 try {
-                  data.forEach(team => {
-                    removeTeam(team.teamId);
-                  });
-                  enqueueSnackbar('Összes csapat törölve', { variant: 'success' });
-                  // Refresh the list
-                  if (typeof window !== 'undefined') {
-                    getAll();
-                  }
-                } catch (e: any) {
-                  enqueueSnackbar(e?.message || 'Hiba történt', { variant: 'error' });
+                  data?.forEach(async a=>{
+                    if(a.relayMatch.state === "IN PROGRESS") {
+                      await addMinutes(a.relayMatch.matchID, values.time);
+                    }
+                    if(a.strategyMatch.state === "IN PROGRESS") {
+                      await addMinutes(a.strategyMatch.matchID, values.time);
+                    }
+                  })
+                  enqueueSnackbar("Sikeres művelet", { variant: 'success' });
+                } catch (e) {
+                  const message = e instanceof Error ? e.message : "Váratlan hiba történt";
+                  enqueueSnackbar(message, { variant: 'error' });
                 }
-              }
-            });
-          }}
-        >
-          Összes csapat törlése
-        </Button>}
-     {adminPageOpen && !teamFromPath && data && <Stats data={data}/>}
+              },
+            })
+          }}>
+          <Stack sx={{display: "flex", flexDirection: "row", margin: "15px"}}>
+          <Field
+            name="time"
+          >
+          {
+            ({field}: FieldProps<string | number>) => <input
+              {...field}
+              className="text-input"
+              placeholder="perc"
+              style={{
+                width: '200px',
+                borderWidth: '2px',
+                borderColor: theme.palette.primary.main,
+              }}
+            />
+          }</Field>
+          <Button sx={{
+            width: '150px',
+            alignSelf: 'center',
+            textTransform: 'none',
+          }} variant='contained' color='primary' type="submit">
+            hozzáadás
+          </Button>
+          </Stack>
+          <ErrorMessage name="time"/><ErrorMessage name="time" render={msg => (
+            <Stack sx={{ color: 'red', fontSize: '0.875rem' }}>
+              {msg}
+            </Stack>
+          )}/>
+        </Form>
+        </Stack>}
+        {!teamFromPath && data &&
+          <Button
+            color="error"
+            variant="contained"
+            sx={{ margin: '10px 0', maxWidth: 300 }}
+            onClick={() => {
+              setConfirmDialog({
+                text: 'Biztosan törlöd az összes csapatot? Ez a művelet nem visszavonható!',
+                confirm: async () => {
+                  try {
+                    data.forEach(team => {
+                      removeTeam(team.teamId);
+                    });
+                    enqueueSnackbar('Összes csapat törölve', { variant: 'success' });
+                    // Refresh the list
+                    if (typeof window !== 'undefined') {
+                      getAll();
+                    }
+                  } catch (e) {
+                    const message = e instanceof Error ? e.message : "Váratlan hiba történt";
+                    enqueueSnackbar(message, { variant: 'error' });
+                  }
+                }
+              });
+            }}
+          >
+            Összes csapat törlése
+          </Button>}
+      {!teamFromPath && data && <Stats data={data}/>}
+      </>}
     </Stack>
   )
 }

--- a/packages/common-frontend/src/client/components/Admin.tsx
+++ b/packages/common-frontend/src/client/components/Admin.tsx
@@ -1,6 +1,7 @@
 import { Stack } from '@mui/system';
 import { useAddMinutes, useAll, useRemoveTeam } from '../hooks/user-hooks';
-import { Button, Dialog, Table, TableCell, TableRow } from '@mui/material';
+import { Button, Dialog, Table, TableCell, TableRow, IconButton } from '@mui/material';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 import { DataGrid } from '@mui/x-data-grid';
@@ -26,6 +27,7 @@ export function Admin(props: {teamId?: string}) {
   const [selectedRow, setSelectedRow] = useState<TeamModelDto | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogInterface | null>(null);
   const [teamFromPath, setTeamFromPath] = useState<TeamModelDto | null>(null);
+  const [adminPageOpen, setAdminPageOpen] = useState<boolean>(true);
 
   useEffect(()=>{
     if (props.teamId) {
@@ -78,11 +80,18 @@ export function Admin(props: {teamId?: string}) {
           {selectedRow && <TeamDetailDialog data={selectedRow} setConfirmDialog={setConfirmDialog}/>}
       </Dialog>
       <ConfirmDialog confirmDialog={confirmDialog}  setConfirmDialog={setConfirmDialog}/>
-      <Stack sx={{width: "100%", display:"flex", flexDirection: "row"}}>
-        <Stack sx={{fontSize:"32px", width: "100%", textAlign: "center"}}>Admin felület </Stack>
+      <Stack sx={{width: "100%", display:"flex", flexDirection: "row", alignItems: "center", justifyContent: "center"}}>
+        <IconButton
+          onClick={() => setAdminPageOpen(!adminPageOpen)}
+          size="large"
+          sx={{marginRight: "8px"}}
+        >
+          {adminPageOpen ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+        </IconButton>
+        <Stack sx={{fontSize:"32px", textAlign: "center"}}>Admin felület </Stack>
       </Stack>
-      {teamFromPath && <TeamDetailDialog data={teamFromPath} setConfirmDialog={setConfirmDialog}/>}
-      {!teamFromPath && <Stack sx={{
+      {adminPageOpen && teamFromPath && <TeamDetailDialog data={teamFromPath} setConfirmDialog={setConfirmDialog}/>}
+      {adminPageOpen && !teamFromPath && <Stack sx={{
         height: "635px",
       }}>
         {data && <DataGrid columns={[
@@ -187,7 +196,7 @@ export function Admin(props: {teamId?: string}) {
         }}
         />}
       </Stack>}
-      {!teamFromPath && data && <Stack sx={{padding: "10px"}}>
+      {adminPageOpen && !teamFromPath && data && <Stack sx={{padding: "10px"}}>
         idő hozzáadása minden aktív játékosnak:
         <Form
         initialValues={{ time: '' }}
@@ -249,7 +258,7 @@ export function Admin(props: {teamId?: string}) {
         )}/>
       </Form>
       </Stack>}
-      {!teamFromPath && data &&
+      {adminPageOpen && !teamFromPath && data &&
         <Button
           color="error"
           variant="contained"
@@ -276,7 +285,7 @@ export function Admin(props: {teamId?: string}) {
         >
           Összes csapat törlése
         </Button>}
-     {!teamFromPath && data && <Stats data={data}/>}
+     {adminPageOpen && !teamFromPath && data && <Stats data={data}/>}
     </Stack>
   )
 }

--- a/packages/common-frontend/src/client/components/ChooserItem.tsx
+++ b/packages/common-frontend/src/client/components/ChooserItem.tsx
@@ -4,7 +4,8 @@ import { MatchStatus, FinishedMatchStatus } from '../dto/TeamStateDto';
 import { useStartRelay, useStartStrategy } from '../hooks/user-hooks';
 import { formatTime } from '../utils/DateFormatter';
 import { useState } from 'react';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useClientRepo } from '../api-repository-interface';
 import { useTheme } from "@mui/material/styles";
 import { useTranslation, Trans } from 'react-i18next';
@@ -50,13 +51,19 @@ export function ChooserItem(props: {
           return !prev
         })
       }}>
-        <span>{props.type==='relay' ? t('relay.name') : t('strategy.name')}  {!props.hideDesc && <ExpandMoreIcon sx={{
+        <span>{props.type==='relay' ? t('relay.name') : t('strategy.name')}  {!props.hideDesc && (mobileDescOpen ? <KeyboardArrowUpIcon sx={{
           fontSize: 33,
           marginBottom: "-9px",
           display: {
             md: 'none',
           }
-        }}/>}</span>
+        }}/> : <KeyboardArrowDownIcon sx={{
+          fontSize: 33,
+          marginBottom: "-9px",
+          display: {
+            md: 'none',
+          }
+        }}/>)}</span>
       </Stack>
       {props.status.state === "FINISHED" &&
         <Stack sx={{

--- a/packages/common-frontend/src/client/components/Disclaimer.tsx
+++ b/packages/common-frontend/src/client/components/Disclaimer.tsx
@@ -121,13 +121,16 @@ export function Disclaimer(props: {teamName: string, category: string}) {
         }}
       >
         <div>
-          <Trans 
-          i18nKey={isOffline ? 'disclaimer.interfaceDescriptionOfflineMode' : 'disclaimer.interfaceDescription'}
-          components={{
-            b: <b />,
-            small: <small />,
-            br: <br />
-          }} />
+          <Trans
+            // t('disclaimer.interfaceDescriptionOfflineMode')
+            // t('disclaimer.interfaceDescription')
+            i18nKey={isOffline ? 'disclaimer.interfaceDescriptionOfflineMode' : 'disclaimer.interfaceDescription'}
+            components={{
+              b: <b />,
+              small: <small />,
+              br: <br />
+            }}
+          />
         </div>
       </Stack>
 

--- a/packages/common-frontend/src/client/components/ExcerciseTask.tsx
+++ b/packages/common-frontend/src/client/components/ExcerciseTask.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Stack } from "@mui/system";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 
 export interface ExcerciseTaskProps {
   task: string;
@@ -14,9 +14,10 @@ export const ExcerciseTask: React.FunctionComponent<ExcerciseTaskProps> = (props
 </latex-js>`;
   const { t } = useTranslation();
   return <Stack>
-    <Stack sx={{fontSize: '20px'}}>
-      {props.serial}. {t('general.task')} ({props.maxPoints} {t('general.point')}):
-    </Stack>
+    <Trans sx={{fontSize: '20px'}}
+      i18nKey='relay.task'
+      values={{ num: props.serial, maxpoints: t('general.points', { count: props.maxPoints})}}
+      />
     <div dangerouslySetInnerHTML={{ __html: completestring }} />
     {props.pictureUrl && <img src={props.pictureUrl} style={{maxWidth:'80%', display: 'flex', marginLeft:'auto', marginRight: 'auto', marginTop: "30px"}} alt={t('relay.taskImage')}/>}
   </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -1,16 +1,19 @@
-import { Container, Dialog, Stack, Button } from '@mui/material';
+import { Container, Dialog, Stack, Button, IconButton } from '@mui/material';
 import { useState } from 'react';
 import { useLogout } from '../hooks/user-hooks';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
+import LanguageIcon from '@mui/icons-material/Language';
 import { useClientRepo } from '../api-repository-interface';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { LanguageSwitcher } from './Langswitcher';
 
-export function Header(props: { teamName: string | null }) {
-  const { t } = useTranslation();
+export function Header(props: { teamName: string | null, admin: boolean }) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'header' });
   const theme = useTheme();
   const logout = useLogout();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [languageSwitcherOpen, setLanguageSwitcherOpen] = useState(false);
   const clientRepository = useClientRepo();
   return (
     <Stack sx={{
@@ -86,6 +89,20 @@ export function Header(props: { teamName: string | null }) {
               flex: 1
             }}>
             </Stack>
+            {props.admin && <IconButton
+              onClick={() => {
+                setLanguageSwitcherOpen(!languageSwitcherOpen);
+              }}
+              sx={{
+                color: theme.palette.primary.contrastText,
+                marginLeft: '10px'
+              }}
+            >
+              <LanguageIcon />
+            </IconButton>}
+            {props.admin && languageSwitcherOpen &&
+            <LanguageSwitcher direction='row' style='dropdown' />
+            }
           </Stack>
         }
         {props.teamName &&<Stack sx={{
@@ -136,6 +153,7 @@ export function Header(props: { teamName: string | null }) {
               textTransform: 'capitalize'
             }}
             >{t('header.logout')}</Button>
+            {props.admin && <LanguageSwitcher />}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Container, Dialog, Stack, Button, IconButton } from '@mui/material';
+import { Container, Dialog, Stack, Button } from '@mui/material';
 import { useState } from 'react';
 import { useLogout } from '../hooks/user-hooks';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
@@ -6,14 +6,13 @@ import LanguageIcon from '@mui/icons-material/Language';
 import { useClientRepo } from '../api-repository-interface';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { LanguageSwitcher } from './Langswitcher';
+import { LanguageDropdown } from './Langswitcher';
 
 export function Header(props: { teamName: string | null, admin: boolean }) {
   const { t } = useTranslation(undefined, { keyPrefix: 'header' });
   const theme = useTheme();
   const logout = useLogout();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [languageSwitcherOpen, setLanguageSwitcherOpen] = useState(false);
   const clientRepository = useClientRepo();
   return (
     <Stack sx={{
@@ -60,51 +59,38 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
           }}>
             {props.teamName &&
               <>
-              <Stack sx={{
-                flex: 1
-              }}></Stack>
-              <Stack sx={{
-                fontSize: 25,
-                display: 'block',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}>{props.teamName}</Stack>
-              <Stack onClick={()=>{
-                logout();
-                if ( clientRepository.version === "OFFLINE") {
-                  window.location.reload();
-                }            
-              }} sx={{
-                fontSize: 20,
-                margin: '0px 15px',
-                cursor: 'pointer',
-                "&:hover": {
-                  opacity: '0.8',
-                }
-              }}>{t('header.logout')}</Stack>
-            </>
+                <Stack sx={{
+                  flex: 1
+                }}></Stack>
+                <Stack sx={{
+                  fontSize: 25,
+                  display: 'block',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}>{props.teamName}</Stack>
+                <Stack onClick={()=>{
+                  logout();
+                  if ( clientRepository.version === "OFFLINE") {
+                    window.location.reload();
+                  }            
+                }} sx={{
+                  fontSize: 20,
+                  margin: '0px 15px',
+                  cursor: 'pointer',
+                  "&:hover": {
+                    opacity: '0.8',
+                  }
+                }}>{t('header.logout')}</Stack>
+              </>
             }
             <Stack sx={{
               flex: 1
             }}>
             </Stack>
-            {props.admin && <>
-              {<IconButton
-                onClick={() => {
-                  setLanguageSwitcherOpen(!languageSwitcherOpen);
-                }}
-                sx={{
-                  color: theme.palette.primary.contrastText,
-                  marginLeft: '10px'
-                }}
-              >
-                <LanguageIcon />
-              </IconButton>}
-              {languageSwitcherOpen &&
-              <LanguageSwitcher variant='dropdown' id={1} />
-              }
-              </>}
+            {props.admin && 
+              <LanguageDropdown id={1} fontColor={theme.palette.primary.contrastText} />
+            }
           </Stack>
         }
         {(props.teamName || props.admin) &&<Stack sx={{
@@ -158,7 +144,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               textTransform: 'capitalize'
             }}
             >{t('header.logout')}</Button>}
-          {props.admin && <LanguageSwitcher id={2} />}
+          {props.admin && <LanguageDropdown id={2} showFlagForSelected={!props.teamName}/>}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -102,7 +102,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
                 <LanguageIcon />
               </IconButton>}
               {languageSwitcherOpen &&
-              <LanguageSwitcher compact={true}/>
+              <LanguageSwitcher variant='dropdown' />
               }
               </>}
           </Stack>
@@ -158,7 +158,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               textTransform: 'capitalize'
             }}
             >{t('header.logout')}</Button>}
-          {props.admin && <LanguageSwitcher compact={true}/>}
+          {props.admin && <LanguageSwitcher />}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -102,7 +102,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
                 <LanguageIcon />
               </IconButton>}
               {languageSwitcherOpen &&
-              <LanguageSwitcher direction='row' style='dropdown' />
+              <LanguageSwitcher variant='dropdown' />
               }
               </>}
           </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -102,7 +102,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
                 <LanguageIcon />
               </IconButton>}
               {languageSwitcherOpen &&
-              <LanguageSwitcher variant='dropdown' />
+              <LanguageSwitcher compact={true}/>
               }
               </>}
           </Stack>
@@ -158,7 +158,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               textTransform: 'capitalize'
             }}
             >{t('header.logout')}</Button>}
-          {props.admin && <LanguageSwitcher />}
+          {props.admin && <LanguageSwitcher compact={true}/>}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { LanguageDropdown } from './Langswitcher';
 
 export function Header(props: { teamName: string | null, admin: boolean }) {
-  const { t } = useTranslation(undefined, { keyPrefix: 'header' });
+  const { t } = useTranslation();
   const theme = useTheme();
   const logout = useLogout();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -89,23 +89,25 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               flex: 1
             }}>
             </Stack>
-            {props.admin && <IconButton
-              onClick={() => {
-                setLanguageSwitcherOpen(!languageSwitcherOpen);
-              }}
-              sx={{
-                color: theme.palette.primary.contrastText,
-                marginLeft: '10px'
-              }}
-            >
-              <LanguageIcon />
-            </IconButton>}
-            {props.admin && languageSwitcherOpen &&
-            <LanguageSwitcher direction='row' style='dropdown' />
-            }
+            {props.admin && <>
+              {<IconButton
+                onClick={() => {
+                  setLanguageSwitcherOpen(!languageSwitcherOpen);
+                }}
+                sx={{
+                  color: theme.palette.primary.contrastText,
+                  marginLeft: '10px'
+                }}
+              >
+                <LanguageIcon />
+              </IconButton>}
+              {languageSwitcherOpen &&
+              <LanguageSwitcher direction='row' style='dropdown' />
+              }
+              </>}
           </Stack>
         }
-        {props.teamName &&<Stack sx={{
+        {(props.teamName || props.admin) &&<Stack sx={{
           display: {
             xs: 'flex',
             md: 'none'
@@ -139,11 +141,14 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
             }
           }}
         >
-           <Stack sx={{
-              fontSize: 30,
-              paddingTop: '10px',
-              paddingBottom: '20px',
-            }}>{props.teamName}</Stack>
+          <Stack sx={{
+            fontSize: 30,
+            paddingTop: '10px',
+            paddingBottom: '20px',
+            display: 'flex',
+            alignItems: 'center'
+          }}>{props.teamName ?? <LanguageIcon sx={{transform: 'scale(2)'}}/>}</Stack>
+          {props.teamName &&
             <Button onClick={()=>{
               setMobileMenuOpen(false);
               logout();
@@ -152,8 +157,8 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               fontSize: 20,
               textTransform: 'capitalize'
             }}
-            >{t('header.logout')}</Button>
-            {props.admin && <LanguageSwitcher />}
+            >{t('header.logout')}</Button>}
+          {props.admin && <LanguageSwitcher />}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -2,7 +2,6 @@ import { Container, Dialog, Stack, Button } from '@mui/material';
 import { useState } from 'react';
 import { useLogout } from '../hooks/user-hooks';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
-import LanguageIcon from '@mui/icons-material/Language';
 import { useClientRepo } from '../api-repository-interface';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
@@ -89,7 +88,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
             }}>
             </Stack>
             {props.admin && 
-              <LanguageDropdown id={1} fontColor={theme.palette.primary.contrastText} />
+              <LanguageDropdown fontColor={theme.palette.primary.contrastText} />
             }
           </Stack>
         }
@@ -127,24 +126,25 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
             }
           }}
         >
-          <Stack sx={{
-            fontSize: 30,
-            paddingTop: '10px',
-            paddingBottom: '20px',
-            display: 'flex',
-            alignItems: 'center'
-          }}>{props.teamName ?? <LanguageIcon sx={{transform: 'scale(2)'}}/>}</Stack>
-          {props.teamName &&
-            <Button onClick={()=>{
-              setMobileMenuOpen(false);
-              logout();
-            }} variant='outlined'
-            sx={{
-              fontSize: 20,
-              textTransform: 'capitalize'
-            }}
-            >{t('header.logout')}</Button>}
-          {props.admin && <LanguageDropdown id={2} showFlagForSelected={!props.teamName}/>}
+          {props.teamName && <>
+              <Stack sx={{
+                fontSize: 30,
+                paddingTop: '10px',
+                paddingBottom: '20px',
+                display: 'flex',
+                alignItems: 'center'
+              }}>{props.teamName}</Stack>
+              <Button onClick={()=>{
+                setMobileMenuOpen(false);
+                logout();
+              }} variant='outlined'
+              sx={{
+                fontSize: 20,
+                textTransform: 'capitalize'
+              }}
+              >{t('header.logout')}</Button>
+            </>}
+          {props.admin && <LanguageDropdown />}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Header.tsx
+++ b/packages/common-frontend/src/client/components/Header.tsx
@@ -102,7 +102,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
                 <LanguageIcon />
               </IconButton>}
               {languageSwitcherOpen &&
-              <LanguageSwitcher variant='dropdown' />
+              <LanguageSwitcher variant='dropdown' id={1} />
               }
               </>}
           </Stack>
@@ -158,7 +158,7 @@ export function Header(props: { teamName: string | null, admin: boolean }) {
               textTransform: 'capitalize'
             }}
             >{t('header.logout')}</Button>}
-          {props.admin && <LanguageSwitcher />}
+          {props.admin && <LanguageSwitcher id={2} />}
         </Dialog>
       </Container>
     </Stack>

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -1,0 +1,86 @@
+import { useTheme } from '@mui/material/styles';
+import i18next from 'i18next';
+import { Select, MenuItem, Stack, Button } from '@mui/material';
+import LanguageIcon from '@mui/icons-material/Language';
+import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
+
+type langNames = Record<string, string>;
+
+export function LanguageSwitcher(props: { direction?: string, style?: string }) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const gap = (props.style === 'simple') ? '0px' : '10px';
+  const languagesArray = Object.keys(i18n.options.resources ?? {})
+  const allLanguages: langNames = {};
+  languagesArray.forEach(l => {
+    allLanguages[l] = t(`languages.${l}`);
+    if (allLanguages[l] === `languages.${l}`) {
+      allLanguages[l] = l;
+    }
+  });
+
+  if (props.style === 'dropdown') {
+    return (
+      <Select
+        value={i18next.language}
+        variant='standard'
+        onChange={(e) => i18next.changeLanguage(e.target.value)}
+        sx={{ 
+          margin: '10px', 
+          minWidth: '80px', 
+          color: theme.palette.primary.contrastText,
+          '& .MuiSvgIcon-root': {
+            fill: theme.palette.primary.contrastText
+          },
+          '&::before': {
+            borderBottom: "transparent",
+          },
+          '&:hover:before': {
+            borderBottom: "2px solid " + theme.palette.primary.contrastText + " !important",
+          }
+        }}
+      >
+        {Object.keys(allLanguages).map((lang) => (
+          <MenuItem key={lang} value={lang}>{allLanguages[lang]}</MenuItem>
+        ))}
+      </Select>
+    );
+  }
+
+  return (
+    <Stack sx={{ display: 'flex', gap: gap, margin: '10px', flexDirection: props.direction ?? 'column'}}>
+      {Object.keys(allLanguages).map((lang) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const stylesObject: any = {opacity: 0.6};
+        if (i18next.language === lang) {
+          stylesObject.opacity = 1;
+          stylesObject["&:hover"] = {backgroundColor: "transparent", cursor: "unset"};
+        }
+        return (
+        <Button
+          key={lang}
+          variant={props.style === 'simple' ? 'text' : 'outlined'}
+          onClick={() => i18next.changeLanguage(lang)}
+          sx={props.style === 'simple' ?
+            {
+              margin: '5px 0px',
+              padding: '0px',
+              fontSize: 13,
+              color: theme.palette.primary.contrastText,
+              background: theme.palette.primary.main,
+              "&:hover": {
+                textDecoration: 'underline'
+              }
+            }
+            : stylesObject
+          }
+        >
+          {props.style !== 'simple' && <LanguageIcon sx={{ paddingRight: '5px' }}/>}
+          {props.style === 'simple' ? lang : allLanguages[lang]}
+        </Button>
+      )}
+    )}
+    </Stack>
+  );
+}

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -2,6 +2,7 @@ import { Theme, useTheme } from "@mui/material/styles";
 import { Select, MenuItem, Stack } from "@mui/material";
 import LanguageIcon from '@mui/icons-material/Language';
 import { useTranslation } from "react-i18next";
+import { useId } from "react"
 
 const Languages = {
   hu: {
@@ -31,8 +32,8 @@ const Languages = {
 type LanguageCode = keyof typeof Languages;
 const supportedCodes = Object.keys(Languages) as LanguageCode[];
 
-const LanguageFlag = ({ langcode, dropdownid }: { langcode: LanguageCode, dropdownid?: number }) => {
-  dropdownid = dropdownid ?? 1;
+const LanguageFlag = ({ langcode }: { langcode: LanguageCode }) => {
+  const dropdownid = useId();
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
       <clipPath id={`clip-${dropdownid}`}>
@@ -56,23 +57,24 @@ const selectSx = (theme: Theme, color?: string) => ({
   },
   "& .MuiSvgIcon-root": { fill: color ?? '#000' },
   "&::before": { borderBottom: "transparent" },
-  "&:hover:before": {
-    borderBottom: "2px solid " + (color ?? theme.palette.primary.main) + " !important",
+  "&&:hover:before": {
+    borderBottom: "2px solid " + (color ?? theme.palette.primary.main),
   },
-  "&::after": {
-    borderBottom: "2px solid " + (color ?? theme.palette.primary.main) + " !important",
+  "&&::after": {
+    borderBottom: "2px solid " + (color ?? theme.palette.primary.main),
   },
 });
 
 function useLanguages() {
   const { i18n } = useTranslation();
-  const i18nCodes = Object.keys(i18n.options.resources ?? {});
+  const i18nCodes = i18n.options.supportedLngs ? i18n.options.supportedLngs : Object.keys(i18n.options.resources ?? {});
+  if (!i18nCodes) return []
   return supportedCodes
     .filter((code) => i18nCodes.includes(code))
     .map((code) => ({ code, label: Languages[code].label }));
 }
 
-export function LanguageDropdown({ id, fontColor, showFlagForSelected } : { id?: number, fontColor?: string, showFlagForSelected?: boolean }) {
+export function LanguageDropdown({ fontColor } : { fontColor?: string }) {
   const theme = useTheme();
   const { i18n } = useTranslation();
   const languages = useLanguages();
@@ -83,23 +85,17 @@ export function LanguageDropdown({ id, fontColor, showFlagForSelected } : { id?:
       variant="standard"
       onChange={(e) => i18n.changeLanguage(e.target.value)}
       sx={selectSx(theme, fontColor)}
-      {...(!showFlagForSelected && { 
-        renderValue: (value) => {
-          const lang = languages.find(({ code }) => code === value);
-          if (!lang) return null;
-          return (
-            <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
-              <LanguageIcon />
-              {lang.label}
-            </Stack>
-          );
-        }
-      })}
+      renderValue={(value) => (
+        <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
+          <LanguageIcon />
+          {languages.find(({ code }) => code === value)?.label}
+        </Stack>
+      )}
     >
       {languages.map(({ code, label }) => (
         <MenuItem key={code} value={code}>
           <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
-            <LanguageFlag langcode={code} dropdownid={id} />
+            <LanguageFlag langcode={code} />
             {label}
           </Stack>
         </MenuItem>

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -1,18 +1,24 @@
-import { useTheme } from '@mui/material/styles';
-import i18next from 'i18next';
-import { Select, MenuItem, Stack, Button } from '@mui/material';
-import LanguageIcon from '@mui/icons-material/Language';
-import { useTranslation } from 'react-i18next';
+import { alpha, SxProps, useTheme } from '@mui/material/styles';
 import i18n from 'i18next';
+import { Select, MenuItem, Stack, Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
-type langNames = Record<string, string>;
+type langNamesByCodes = Record<string, string>;
+type langFlagsByCodes = Record<string, string>;
 
-export function LanguageSwitcher(props: { direction?: string, style?: string }) {
+interface langButtonStyles {
+  opacity: number;
+  "&:hover"?: SxProps;
+}
+
+export function LanguageSwitcher(props: { direction?: ("column"|"row"), style?: ("simple"|"dropdown"|"simple-dropdown") }) {
   const theme = useTheme();
   const { t } = useTranslation();
   const gap = (props.style === 'simple') ? '0px' : '10px';
   const languagesArray = Object.keys(i18n.options.resources ?? {})
-  const allLanguages: langNames = {};
+  const allLanguages: langNamesByCodes = {};
+  const flagFileNames: langFlagsByCodes = {"en": "flag-united-kingdom_1f1ec-1f1e7.png", "hu": "flag-hungary_1f1ed-1f1fa.png"};
+  const languageFlag = (lang: string) => <img src={`https://em-content.zobj.net/source/catrinity/458/${flagFileNames[lang]}`} style={{ width: '24px', height: '24px' }}/> 
   languagesArray.forEach(l => {
     allLanguages[l] = t(`languages.${l}`);
     if (allLanguages[l] === `languages.${l}`) {
@@ -20,12 +26,12 @@ export function LanguageSwitcher(props: { direction?: string, style?: string }) 
     }
   });
 
-  if (props.style === 'dropdown') {
+  if (props.style?.includes('dropdown')) {
     return (
       <Select
-        value={i18next.language}
+        value={i18n.language}
         variant='standard'
-        onChange={(e) => i18next.changeLanguage(e.target.value)}
+        onChange={(e) => i18n.changeLanguage(e.target.value)}
         sx={{ 
           margin: '10px', 
           minWidth: '80px', 
@@ -42,7 +48,11 @@ export function LanguageSwitcher(props: { direction?: string, style?: string }) 
         }}
       >
         {Object.keys(allLanguages).map((lang) => (
-          <MenuItem key={lang} value={lang}>{allLanguages[lang]}</MenuItem>
+          <MenuItem key={lang} value={lang}>{
+            props.style?.includes("simple") 
+              ? lang.toUpperCase() 
+              : <Stack sx={{ display: 'flex', alignItems: 'center', gap: '8px', flexDirection: "row" }}>{languageFlag(lang)}{allLanguages[lang]}</Stack>
+          }</MenuItem>
         ))}
       </Select>
     );
@@ -51,17 +61,16 @@ export function LanguageSwitcher(props: { direction?: string, style?: string }) 
   return (
     <Stack sx={{ display: 'flex', gap: gap, margin: '10px', flexDirection: props.direction ?? 'column'}}>
       {Object.keys(allLanguages).map((lang) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const stylesObject: any = {opacity: 0.6};
-        if (i18next.language === lang) {
+        const stylesObject: langButtonStyles = {opacity: 0.6};
+        if (i18n.language === lang) {
           stylesObject.opacity = 1;
-          stylesObject["&:hover"] = {backgroundColor: "transparent", cursor: "unset"};
+          stylesObject["&:hover"] = {backgroundColor: "transparent", cursor: "unset", borderColor: alpha(theme.palette.primary.main, 0.5)};
         }
         return (
         <Button
           key={lang}
           variant={props.style === 'simple' ? 'text' : 'outlined'}
-          onClick={() => i18next.changeLanguage(lang)}
+          onClick={() => i18n.changeLanguage(lang)}
           sx={props.style === 'simple' ?
             {
               margin: '5px 0px',
@@ -76,7 +85,7 @@ export function LanguageSwitcher(props: { direction?: string, style?: string }) 
             : stylesObject
           }
         >
-          {props.style !== 'simple' && <LanguageIcon sx={{ paddingRight: '5px' }}/>}
+          {props.style !== 'simple' && languageFlag(lang)}
           {props.style === 'simple' ? lang : allLanguages[lang]}
         </Button>
       )}

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -65,7 +65,7 @@ const selectSx = (theme: Theme, color?: string) => ({
 function useLanguages(): Language[] {
   const { i18n } = useTranslation();
   return Object.keys(i18n.options.resources ?? {}).map((code) => (
-    { code, label: KnownLanguageNames[code] ?? code }
+    { code, label: KnownLanguageNames[code] ?? code.toUpperCase() }
   ));
 }
 

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -1,11 +1,14 @@
-import { alpha, Theme, useTheme } from "@mui/material/styles";
-import { Select, MenuItem, Stack, Button } from "@mui/material";
+import { Theme, useTheme } from "@mui/material/styles";
+import { Select, MenuItem, Stack } from "@mui/material";
+import LanguageIcon from '@mui/icons-material/Language';
 import { useTranslation } from "react-i18next";
 
 interface Language {
-  code: string;
-  label: string;
+  code: string,
+  label: string
 }
+
+const KnownLanguageNames: Record<string, string> = {'en': 'English', 'hu': 'Magyar'}
 
 const Flags: Record<string, JSX.Element> = {
   hu: (
@@ -26,51 +29,47 @@ const Flags: Record<string, JSX.Element> = {
   ),
 };
 
-const LanguageFlag = ({ code, id }: { code: string, id?: number }) => {
-  id = id ?? 1;
+const LanguageFlag = ({ langcode, dropdownid }: { langcode: string, dropdownid?: number }) => {
+  dropdownid = dropdownid ?? 1;
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
-      <clipPath id={`c${id}`}>
+      <clipPath id={`clip-${dropdownid}`}>
         <circle cx="30" cy="30" r="30" />
       </clipPath>
-      <g clipPath={`url(#c${id})`}>
-        {Flags[code] ?? null}
+      <g clipPath={`url(#clip-${dropdownid})`}>
+        {Flags[langcode] ?? null}
       </g>
     </svg>
   );
 }
 
-const selectSx = (theme: Theme) => ({
+const selectSx = (theme: Theme, color?: string) => ({
   margin: "10px",
   minWidth: "80px",
-  color: theme.palette.primary.contrastText,
-  "& .MuiSvgIcon-root": { fill: theme.palette.primary.contrastText },
+  color: color ?? '#000',
+  border: theme.palette.primary.main + " 1px solid",
+  borderRadius: "3px",
+  "& .MuiInput-input": {
+    padding: "5px 8px",
+  },
+  "& .MuiSvgIcon-root": { fill: color ?? '#000' },
   "&::before": { borderBottom: "transparent" },
   "&:hover:before": {
-    borderBottom: "2px solid " + theme.palette.primary.contrastText + " !important",
+    borderBottom: "2px solid " + (color ?? theme.palette.primary.main) + " !important",
   },
-});
-
-const selectableButtonSx = { opacity: 0.6, gap: '8px' };
-const selectedButtonSx = (theme: Theme) => ({
-  gap: '8px',
-  opacity: 1,
-  "&:hover": {
-    backgroundColor: "transparent",
-    cursor: "unset",
-    borderColor: alpha(theme.palette.primary.main, 0.5),
+  "&::after": {
+    borderBottom: "2px solid " + (color ?? theme.palette.primary.main) + " !important",
   },
 });
 
 function useLanguages(): Language[] {
-  const { t, i18n } = useTranslation();
-  return Object.keys(i18n.options.resources ?? {}).map((code) => {
-    const label = t(`languages.${code}`);
-    return { code, label: label === `languages.${code}` ? code : label };
-  });
+  const { i18n } = useTranslation();
+  return Object.keys(i18n.options.resources ?? {}).map((code) => (
+    { code, label: KnownLanguageNames[code] ?? code }
+  ));
 }
 
-function LanguageDropdown({ compact, id }: { compact: boolean, id: number }) {
+export function LanguageDropdown({ id, fontColor, showFlagForSelected } : { id?: number, fontColor?: string, showFlagForSelected?: boolean }) {
   const theme = useTheme();
   const { i18n } = useTranslation();
   const languages = useLanguages();
@@ -79,56 +78,29 @@ function LanguageDropdown({ compact, id }: { compact: boolean, id: number }) {
     <Select
       value={i18n.language}
       variant="standard"
-      onChange={(e) => i18n.changeLanguage(e.target.value)}
-      sx={selectSx(theme)}
+      onChange={(e) => i18n.changeLanguage(e.target.value as string)}
+      sx={selectSx(theme, fontColor)}
+      {...(!showFlagForSelected && { 
+        renderValue: (value) => {
+          const lang = languages.find(({ code }) => code === value);
+          if (!lang) return null;
+          return (
+            <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
+              <LanguageIcon />
+              {lang.label}
+            </Stack>
+          );
+        }
+      })}
     >
       {languages.map(({ code, label }) => (
         <MenuItem key={code} value={code}>
-          {compact ? (
-            code.toUpperCase()
-          ) : (
-            <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
-              <LanguageFlag code={code} id={id} />
-              {label}
-            </Stack>
-          )}
+          <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
+            <LanguageFlag langcode={code} dropdownid={id} />
+            {label}
+          </Stack>
         </MenuItem>
       ))}
     </Select>
   );
-}
-
-function LanguageButtons({ compact, direction, id }: { compact: boolean; direction: "column" | "row", id: number }) {
-  const theme = useTheme();
-  const { i18n } = useTranslation();
-  const languages = useLanguages();
-  const gap = compact ? "0px" : "10px";
-
-  return (
-    <Stack sx={{ display: "flex", gap, margin: "10px", flexDirection: direction }}>
-      {languages.map(({ code, label }) => {
-        const isActive = i18n.language === code;
-        const sx = !compact && isActive ? selectedButtonSx(theme) : selectableButtonSx;
-        return (
-          <Button key={code} variant={compact ? "text" : "outlined"} onClick={() => i18n.changeLanguage(code)} sx={sx}>
-            {!compact && <LanguageFlag code={code} id={id} />}
-            {compact ? code : label}
-          </Button>
-        );
-      })}
-    </Stack>
-  );
-}
-
-export function LanguageSwitcher(props: {
-  id: number;
-  direction?: "column" | "row";
-  variant?: "dropdown" | "buttons";
-  compact?: boolean;
-}) {
-  const compact = props.compact ?? false;
-  if (props.variant === "dropdown") {
-    return <LanguageDropdown compact={compact} id={props.id} />;
-  }
-  return <LanguageButtons compact={compact} direction={props.direction ?? "column"} id={props.id} />;
 }

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -3,33 +3,35 @@ import { Select, MenuItem, Stack } from "@mui/material";
 import LanguageIcon from '@mui/icons-material/Language';
 import { useTranslation } from "react-i18next";
 
-interface Language {
-  code: string,
-  label: string
-}
+const Languages = {
+  hu: {
+    label: 'Magyar',
+    flag: (
+      <>
+        <path fill="#ce2939" d="M0 0h60v20H0z" />
+        <path fill="#fff" d="M0 20h60v20H0z" />
+        <path fill="#477050" d="M0 40h60v20H0z" />
+      </>
+    ),
+  },
+  en: {
+    label: 'English',
+    flag: (
+      <>
+        <path fill="#012169" d="M0 0h60v60H0z" />
+        <path stroke="#fff" strokeWidth="12" d="M0 0 60 60M60 0 0 60" />
+        <path stroke="#C8102E" strokeWidth="7" d="M0 0 60 60M60 0 0 60" />
+        <path stroke="#fff" strokeWidth="20" d="M30 0v60M0 30h60" />
+        <path stroke="#C8102E" strokeWidth="12" d="M30 0v60M0 30h60" />
+      </>
+    ),
+  },
+} as const;
 
-const KnownLanguageNames: Record<string, string> = {'en': 'English', 'hu': 'Magyar'}
+type LanguageCode = keyof typeof Languages;
+const supportedCodes = Object.keys(Languages) as LanguageCode[];
 
-const Flags: Record<string, JSX.Element> = {
-  hu: (
-    <>
-      <path fill="#ce2939" d="M0 0h60v20H0z" />
-      <path fill="#fff" d="M0 20h60v20H0z" />
-      <path fill="#477050" d="M0 40h60v20H0z" />
-    </>
-  ),
-  en: (
-    <>
-      <path fill="#012169" d="M0 0h60v60H0z" />
-      <path stroke="#fff" strokeWidth="12" d="M0 0 60 60M60 0 0 60" />
-      <path stroke="#C8102E" strokeWidth="7" d="M0 0 60 60M60 0 0 60" />
-      <path stroke="#fff" strokeWidth="20" d="M30 0v60M0 30h60" />
-      <path stroke="#C8102E" strokeWidth="12" d="M30 0v60M0 30h60" />
-    </>
-  ),
-};
-
-const LanguageFlag = ({ langcode, dropdownid }: { langcode: string, dropdownid?: number }) => {
+const LanguageFlag = ({ langcode, dropdownid }: { langcode: LanguageCode, dropdownid?: number }) => {
   dropdownid = dropdownid ?? 1;
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
@@ -37,7 +39,7 @@ const LanguageFlag = ({ langcode, dropdownid }: { langcode: string, dropdownid?:
         <circle cx="30" cy="30" r="30" />
       </clipPath>
       <g clipPath={`url(#clip-${dropdownid})`}>
-        {Flags[langcode] ?? null}
+        {Languages[langcode].flag}
       </g>
     </svg>
   );
@@ -62,11 +64,12 @@ const selectSx = (theme: Theme, color?: string) => ({
   },
 });
 
-function useLanguages(): Language[] {
+function useLanguages() {
   const { i18n } = useTranslation();
-  return Object.keys(i18n.options.resources ?? {}).map((code) => (
-    { code, label: KnownLanguageNames[code] ?? code.toUpperCase() }
-  ));
+  const i18nCodes = Object.keys(i18n.options.resources ?? {});
+  return supportedCodes
+    .filter((code) => i18nCodes.includes(code))
+    .map((code) => ({ code, label: Languages[code].label }));
 }
 
 export function LanguageDropdown({ id, fontColor, showFlagForSelected } : { id?: number, fontColor?: string, showFlagForSelected?: boolean }) {
@@ -75,10 +78,10 @@ export function LanguageDropdown({ id, fontColor, showFlagForSelected } : { id?:
   const languages = useLanguages();
 
   return (
-    <Select
+    <Select<string>
       value={i18n.language}
       variant="standard"
-      onChange={(e) => i18n.changeLanguage(e.target.value as string)}
+      onChange={(e) => i18n.changeLanguage(e.target.value)}
       sx={selectSx(theme, fontColor)}
       {...(!showFlagForSelected && { 
         renderValue: (value) => {

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -9,34 +9,36 @@ interface Language {
 
 const Flags: Record<string, JSX.Element> = {
   hu: (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
-      <clipPath id="a">
-        <circle cx="30" cy="30" r="30" />
-      </clipPath>
-      <g clipPath="url(#a)">
-        <path fill="#ce2939" d="M0 0h60v20H0z" />
-        <path fill="#fff" d="M0 20h60v20H0z" />
-        <path fill="#477050" d="M0 40h60v20H0z" />
-      </g>
-    </svg>
+    <>
+      <path fill="#ce2939" d="M0 0h60v20H0z" />
+      <path fill="#fff" d="M0 20h60v20H0z" />
+      <path fill="#477050" d="M0 40h60v20H0z" />
+    </>
   ),
   en: (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
-      <clipPath id="a2">
-        <circle cx="30" cy="30" r="30" />
-      </clipPath>
-      <g clipPath="url(#a2)">
-        <path fill="#012169" d="M0 0h60v60H0z" />
-        <path stroke="#fff" strokeWidth="12" d="M0 0 60 60M60 0 0 60" />
-        <path stroke="#C8102E" strokeWidth="7" d="M0 0 60 60M60 0 0 60" />
-        <path stroke="#fff" strokeWidth="20" d="M30 0v60M0 30h60" />
-        <path stroke="#C8102E" strokeWidth="12" d="M30 0v60M0 30h60" />
-      </g>
-    </svg>
+    <>
+      <path fill="#012169" d="M0 0h60v60H0z" />
+      <path stroke="#fff" strokeWidth="12" d="M0 0 60 60M60 0 0 60" />
+      <path stroke="#C8102E" strokeWidth="7" d="M0 0 60 60M60 0 0 60" />
+      <path stroke="#fff" strokeWidth="20" d="M30 0v60M0 30h60" />
+      <path stroke="#C8102E" strokeWidth="12" d="M30 0v60M0 30h60" />
+    </>
   ),
 };
 
-const LanguageFlag = ({ code }: { code: string }) => Flags[code] ?? null;
+const LanguageFlag = ({ code, id }: { code: string, id?: number }) => {
+  id = id ?? 1;
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
+      <clipPath id={`c${id}`}>
+        <circle cx="30" cy="30" r="30" />
+      </clipPath>
+      <g clipPath={`url(#c${id})`}>
+        {Flags[code] ?? null}
+      </g>
+    </svg>
+  );
+}
 
 const selectSx = (theme: Theme) => ({
   margin: "10px",
@@ -68,7 +70,7 @@ function useLanguages(): Language[] {
   });
 }
 
-function LanguageDropdown({ compact }: { compact: boolean }) {
+function LanguageDropdown({ compact, id }: { compact: boolean, id: number }) {
   const theme = useTheme();
   const { i18n } = useTranslation();
   const languages = useLanguages();
@@ -86,7 +88,7 @@ function LanguageDropdown({ compact }: { compact: boolean }) {
             code.toUpperCase()
           ) : (
             <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
-              <LanguageFlag code={code} />
+              <LanguageFlag code={code} id={id} />
               {label}
             </Stack>
           )}
@@ -96,7 +98,7 @@ function LanguageDropdown({ compact }: { compact: boolean }) {
   );
 }
 
-function LanguageButtons({ compact, direction }: { compact: boolean; direction: "column" | "row" }) {
+function LanguageButtons({ compact, direction, id }: { compact: boolean; direction: "column" | "row", id: number }) {
   const theme = useTheme();
   const { i18n } = useTranslation();
   const languages = useLanguages();
@@ -109,7 +111,7 @@ function LanguageButtons({ compact, direction }: { compact: boolean; direction: 
         const sx = !compact && isActive ? selectedButtonSx(theme) : selectableButtonSx;
         return (
           <Button key={code} variant={compact ? "text" : "outlined"} onClick={() => i18n.changeLanguage(code)} sx={sx}>
-            {!compact && <LanguageFlag code={code} />}
+            {!compact && <LanguageFlag code={code} id={id} />}
             {compact ? code : label}
           </Button>
         );
@@ -119,13 +121,14 @@ function LanguageButtons({ compact, direction }: { compact: boolean; direction: 
 }
 
 export function LanguageSwitcher(props: {
+  id: number;
   direction?: "column" | "row";
   variant?: "dropdown" | "buttons";
   compact?: boolean;
 }) {
   const compact = props.compact ?? false;
   if (props.variant === "dropdown") {
-    return <LanguageDropdown compact={compact} />;
+    return <LanguageDropdown compact={compact} id={props.id} />;
   }
-  return <LanguageButtons compact={compact} direction={props.direction ?? "column"} />;
+  return <LanguageButtons compact={compact} direction={props.direction ?? "column"} id={props.id} />;
 }

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -49,8 +49,9 @@ const selectSx = (theme: Theme) => ({
   },
 });
 
-const selectableButtonSx = { opacity: 0.6 };
+const selectableButtonSx = { opacity: 0.6, gap: '8px' };
 const selectedButtonSx = (theme: Theme) => ({
+  gap: '8px',
   opacity: 1,
   "&:hover": {
     backgroundColor: "transparent",

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -7,15 +7,36 @@ interface Language {
   label: string;
 }
 
-const FLAG_BASE_URL = "https://em-content.zobj.net/source/catrinity/458/";
-const flagFileNames: Record<string, string> = {
-  en: "flag-united-kingdom_1f1ec-1f1e7.png",
-  hu: "flag-hungary_1f1ed-1f1fa.png",
+const Flags: Record<string, JSX.Element> = {
+  hu: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
+      <clipPath id="a">
+        <circle cx="30" cy="30" r="30" />
+      </clipPath>
+      <g clipPath="url(#a)">
+        <path fill="#ce2939" d="M0 0h60v20H0z" />
+        <path fill="#fff" d="M0 20h60v20H0z" />
+        <path fill="#477050" d="M0 40h60v20H0z" />
+      </g>
+    </svg>
+  ),
+  en: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="24" height="24">
+      <clipPath id="a2">
+        <circle cx="30" cy="30" r="30" />
+      </clipPath>
+      <g clipPath="url(#a2)">
+        <path fill="#012169" d="M0 0h60v60H0z" />
+        <path stroke="#fff" strokeWidth="12" d="M0 0 60 60M60 0 0 60" />
+        <path stroke="#C8102E" strokeWidth="7" d="M0 0 60 60M60 0 0 60" />
+        <path stroke="#fff" strokeWidth="20" d="M30 0v60M0 30h60" />
+        <path stroke="#C8102E" strokeWidth="12" d="M30 0v60M0 30h60" />
+      </g>
+    </svg>
+  ),
 };
 
-const LanguageFlag = ({ code }: { code: string }) => (
-  <img src={`${FLAG_BASE_URL}${flagFileNames[code]}`} style={{ width: "24px", height: "24px" }} />
-);
+const LanguageFlag = ({ code }: { code: string }) => Flags[code] ?? null;
 
 const selectSx = (theme: Theme) => ({
   margin: "10px",
@@ -26,15 +47,6 @@ const selectSx = (theme: Theme) => ({
   "&:hover:before": {
     borderBottom: "2px solid " + theme.palette.primary.contrastText + " !important",
   },
-});
-
-const simpleButtonSx = (theme: Theme) => ({
-  margin: "5px 0px",
-  padding: "0px",
-  fontSize: 13,
-  color: theme.palette.primary.contrastText,
-  background: theme.palette.primary.main,
-  "&:hover": { textDecoration: "underline" },
 });
 
 const selectableButtonSx = { opacity: 0.6 };
@@ -93,7 +105,7 @@ function LanguageButtons({ compact, direction }: { compact: boolean; direction: 
     <Stack sx={{ display: "flex", gap, margin: "10px", flexDirection: direction }}>
       {languages.map(({ code, label }) => {
         const isActive = i18n.language === code;
-        const sx = compact ? simpleButtonSx(theme) : isActive ? selectedButtonSx(theme) : selectableButtonSx;
+        const sx = !compact && isActive ? selectedButtonSx(theme) : selectableButtonSx;
         return (
           <Button key={code} variant={compact ? "text" : "outlined"} onClick={() => i18n.changeLanguage(code)} sx={sx}>
             {!compact && <LanguageFlag code={code} />}

--- a/packages/common-frontend/src/client/components/Langswitcher.tsx
+++ b/packages/common-frontend/src/client/components/Langswitcher.tsx
@@ -1,95 +1,118 @@
-import { alpha, SxProps, useTheme } from '@mui/material/styles';
-import i18n from 'i18next';
-import { Select, MenuItem, Stack, Button } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { alpha, Theme, useTheme } from "@mui/material/styles";
+import { Select, MenuItem, Stack, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
-type langNamesByCodes = Record<string, string>;
-type langFlagsByCodes = Record<string, string>;
-
-interface langButtonStyles {
-  opacity: number;
-  "&:hover"?: SxProps;
+interface Language {
+  code: string;
+  label: string;
 }
 
-export function LanguageSwitcher(props: { direction?: ("column"|"row"), style?: ("simple"|"dropdown"|"simple-dropdown") }) {
-  const theme = useTheme();
-  const { t } = useTranslation();
-  const gap = (props.style === 'simple') ? '0px' : '10px';
-  const languagesArray = Object.keys(i18n.options.resources ?? {})
-  const allLanguages: langNamesByCodes = {};
-  const flagFileNames: langFlagsByCodes = {"en": "flag-united-kingdom_1f1ec-1f1e7.png", "hu": "flag-hungary_1f1ed-1f1fa.png"};
-  const languageFlag = (lang: string) => <img src={`https://em-content.zobj.net/source/catrinity/458/${flagFileNames[lang]}`} style={{ width: '24px', height: '24px' }}/> 
-  languagesArray.forEach(l => {
-    allLanguages[l] = t(`languages.${l}`);
-    if (allLanguages[l] === `languages.${l}`) {
-      allLanguages[l] = l;
-    }
-  });
+const FLAG_BASE_URL = "https://em-content.zobj.net/source/catrinity/458/";
+const flagFileNames: Record<string, string> = {
+  en: "flag-united-kingdom_1f1ec-1f1e7.png",
+  hu: "flag-hungary_1f1ed-1f1fa.png",
+};
 
-  if (props.style?.includes('dropdown')) {
-    return (
-      <Select
-        value={i18n.language}
-        variant='standard'
-        onChange={(e) => i18n.changeLanguage(e.target.value)}
-        sx={{ 
-          margin: '10px', 
-          minWidth: '80px', 
-          color: theme.palette.primary.contrastText,
-          '& .MuiSvgIcon-root': {
-            fill: theme.palette.primary.contrastText
-          },
-          '&::before': {
-            borderBottom: "transparent",
-          },
-          '&:hover:before': {
-            borderBottom: "2px solid " + theme.palette.primary.contrastText + " !important",
-          }
-        }}
-      >
-        {Object.keys(allLanguages).map((lang) => (
-          <MenuItem key={lang} value={lang}>{
-            props.style?.includes("simple") 
-              ? lang.toUpperCase() 
-              : <Stack sx={{ display: 'flex', alignItems: 'center', gap: '8px', flexDirection: "row" }}>{languageFlag(lang)}{allLanguages[lang]}</Stack>
-          }</MenuItem>
-        ))}
-      </Select>
-    );
-  }
+const LanguageFlag = ({ code }: { code: string }) => (
+  <img src={`${FLAG_BASE_URL}${flagFileNames[code]}`} style={{ width: "24px", height: "24px" }} />
+);
+
+const selectSx = (theme: Theme) => ({
+  margin: "10px",
+  minWidth: "80px",
+  color: theme.palette.primary.contrastText,
+  "& .MuiSvgIcon-root": { fill: theme.palette.primary.contrastText },
+  "&::before": { borderBottom: "transparent" },
+  "&:hover:before": {
+    borderBottom: "2px solid " + theme.palette.primary.contrastText + " !important",
+  },
+});
+
+const simpleButtonSx = (theme: Theme) => ({
+  margin: "5px 0px",
+  padding: "0px",
+  fontSize: 13,
+  color: theme.palette.primary.contrastText,
+  background: theme.palette.primary.main,
+  "&:hover": { textDecoration: "underline" },
+});
+
+const selectableButtonSx = { opacity: 0.6 };
+const selectedButtonSx = (theme: Theme) => ({
+  opacity: 1,
+  "&:hover": {
+    backgroundColor: "transparent",
+    cursor: "unset",
+    borderColor: alpha(theme.palette.primary.main, 0.5),
+  },
+});
+
+function useLanguages(): Language[] {
+  const { t, i18n } = useTranslation();
+  return Object.keys(i18n.options.resources ?? {}).map((code) => {
+    const label = t(`languages.${code}`);
+    return { code, label: label === `languages.${code}` ? code : label };
+  });
+}
+
+function LanguageDropdown({ compact }: { compact: boolean }) {
+  const theme = useTheme();
+  const { i18n } = useTranslation();
+  const languages = useLanguages();
 
   return (
-    <Stack sx={{ display: 'flex', gap: gap, margin: '10px', flexDirection: props.direction ?? 'column'}}>
-      {Object.keys(allLanguages).map((lang) => {
-        const stylesObject: langButtonStyles = {opacity: 0.6};
-        if (i18n.language === lang) {
-          stylesObject.opacity = 1;
-          stylesObject["&:hover"] = {backgroundColor: "transparent", cursor: "unset", borderColor: alpha(theme.palette.primary.main, 0.5)};
-        }
+    <Select
+      value={i18n.language}
+      variant="standard"
+      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      sx={selectSx(theme)}
+    >
+      {languages.map(({ code, label }) => (
+        <MenuItem key={code} value={code}>
+          {compact ? (
+            code.toUpperCase()
+          ) : (
+            <Stack sx={{ display: "flex", alignItems: "center", gap: "8px", flexDirection: "row" }}>
+              <LanguageFlag code={code} />
+              {label}
+            </Stack>
+          )}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+function LanguageButtons({ compact, direction }: { compact: boolean; direction: "column" | "row" }) {
+  const theme = useTheme();
+  const { i18n } = useTranslation();
+  const languages = useLanguages();
+  const gap = compact ? "0px" : "10px";
+
+  return (
+    <Stack sx={{ display: "flex", gap, margin: "10px", flexDirection: direction }}>
+      {languages.map(({ code, label }) => {
+        const isActive = i18n.language === code;
+        const sx = compact ? simpleButtonSx(theme) : isActive ? selectedButtonSx(theme) : selectableButtonSx;
         return (
-        <Button
-          key={lang}
-          variant={props.style === 'simple' ? 'text' : 'outlined'}
-          onClick={() => i18n.changeLanguage(lang)}
-          sx={props.style === 'simple' ?
-            {
-              margin: '5px 0px',
-              padding: '0px',
-              fontSize: 13,
-              color: theme.palette.primary.contrastText,
-              background: theme.palette.primary.main,
-              "&:hover": {
-                textDecoration: 'underline'
-              }
-            }
-            : stylesObject
-          }
-        >
-          {props.style !== 'simple' && languageFlag(lang)}
-          {props.style === 'simple' ? lang : allLanguages[lang]}
-        </Button>
-      )}
-    )}
+          <Button key={code} variant={compact ? "text" : "outlined"} onClick={() => i18n.changeLanguage(code)} sx={sx}>
+            {!compact && <LanguageFlag code={code} />}
+            {compact ? code : label}
+          </Button>
+        );
+      })}
     </Stack>
   );
+}
+
+export function LanguageSwitcher(props: {
+  direction?: "column" | "row";
+  variant?: "dropdown" | "buttons";
+  compact?: boolean;
+}) {
+  const compact = props.compact ?? false;
+  if (props.variant === "dropdown") {
+    return <LanguageDropdown compact={compact} />;
+  }
+  return <LanguageButtons compact={compact} direction={props.direction ?? "column"} />;
 }

--- a/packages/common-frontend/src/client/components/Main.tsx
+++ b/packages/common-frontend/src/client/components/Main.tsx
@@ -28,7 +28,7 @@ export function Main(props: { language: string, gitCommitHash: string }) {
   return (
     <Layout>
       <LoadTeamState />
-      <Header teamName={teamState?.teamName ?? null} />
+      <Header teamName={teamState?.teamName ?? null} admin={admin}/>
       <Container
         sx={{
           paddingLeft: {
@@ -49,7 +49,7 @@ export function Main(props: { language: string, gitCommitHash: string }) {
         data-testId="mainRoot"
       >
         {admin && <Admin teamId={window.location.pathname.split('/').at(2)}/>}
-        {!teamState && !admin && <Login />}
+        {!teamState && <Login />}
         {teamState && teamState.pageState === "DISCLAIMER" && (
           <Disclaimer teamName={teamState.teamName} category={teamState.category}/>
         )}

--- a/packages/common-frontend/src/client/components/StrategyEndTable.tsx
+++ b/packages/common-frontend/src/client/components/StrategyEndTable.tsx
@@ -30,7 +30,7 @@ export function StrategyEndTable(props: {allPoints: number, numOfTries: number})
         fontSize: '18px',
         fontWeight: 'bold',
         textAlign: 'center'
-    }}>{t('relay.endTable.all')}</Stack>
+    }}>{t('strategy.endTable.all')}</Stack>
       <Stack sx={{
           marginTop: '25px',
           display: 'flex',

--- a/packages/common-frontend/src/client/index.ts
+++ b/packages/common-frontend/src/client/index.ts
@@ -8,6 +8,7 @@ export * from './components/Disclaimer';
 export * from './components/ExcerciseForm';
 export * from './components/ExcerciseTask';
 export * from './components/Header';
+export * from './components/Langswitcher';
 export * from './components/Layout';
 export * from './components/Login';
 export * from './components/Main';

--- a/packages/common-frontend/src/common/i18n.ts
+++ b/packages/common-frontend/src/common/i18n.ts
@@ -15,11 +15,11 @@ i18next
     defaultNS: 'translation',
     resources: {
       en: {
-        ...enTranslation,
+        translation: enTranslation,
       },
       hu: {
-        ...huTranslation,
-      },
+        translation: huTranslation,
+      }
     },
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
Resolves: #210, resolves: #214

# Experience
Standard: <img width="1433" height="494" alt="image" src="https://github.com/user-attachments/assets/762d3fa0-c990-473c-8303-f4e1fb148751" />

<details><summary>Mobile when logged in:</summary>
<img width="240" height="227" alt="image" src="https://github.com/user-attachments/assets/0210fda2-31b9-4e75-9d06-cbb251b7b418" /></details>

<details><summary>(REMOVED) Mobile when not logged in:</summary>
<img width="253" height="201" alt="image" src="https://github.com/user-attachments/assets/383a6e4d-4f0e-4ab3-b66b-a04003206de8" />

Update: it's now the same as logged in.</details>



# Additional changes 

Also enhanced the admin page by making it collabsible, and worked on the design of collabsibles as well.

# Notes

It should be merged after [PR#207](https://github.com/a-gondolkodas-orome/durer-aion/pull/207) (it is completely in sync with that PR)

Co-authored-by: Copilot [copilot@github.com](mailto:copilot@github.com)